### PR TITLE
Clarify deprecation of energy incentives v1 API

### DIFF
--- a/source/docs/electricity/energy-incentives-v1.md.erb
+++ b/source/docs/electricity/energy-incentives-v1.md.erb
@@ -1,7 +1,7 @@
 ---
-title: Energy Incentives (Deprecated)
-summary: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
-  quantitative spreadsheet by location.
+title: Energy Incentives (Version 1 - Deprecated)
+summary: 'Deprecated: We encourage you to migrate to [version 2](/docs/electricity/energy-incentives-v2/)
+  of the utility rates API.'
 url: GET /api/energy-incentives/v1
 deprecated: true
 
@@ -10,9 +10,9 @@ deprecated: true
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 <%= current_page.data.summary %>
 
-This is the current version of the energy incentives API. Previous versions have been deprecated and its users are encouraged to migrate to this newly enhanced version.
+This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/) quantitative spreadsheet by location.
 
-<div class="alert alert-error">
+<div class="alert alert-danger">
   <p>The DSIRE database, which is managed by the the North Carolina Solar Center and provides the quantitative data that support this web service, is undergoing substantial changes with their new contract with DOE. This transition will involve a significant gap in the provision of the quantitative data that support this web service. As a result of this, the data available in this web service will not be updated between Sept 1st and June 30th. The service will remain active to ensure that the best available data remains accessible.</p>
 
   <p>Announcement from DSIRE: The U.S. Department of Energy and the North Carolina Solar Center are excited to announce that a new, modernized DSIRE is under construction. The new version of DSIRE will offer significant improvements over the current version, including expanded data accessibility and an array of new tools for site users. The new DSIRE site will be available in the summer of 2014. Staff are currently working hard on the new DSIRE and are unfortunately only able to make minimal updates to the DSIRE website at this time. We apologize for any inconvenience and thank you for using DSIRE.</p>

--- a/source/docs/electricity/energy-incentives-v2.md.erb
+++ b/source/docs/electricity/energy-incentives-v2.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Energy Incentives
+title: Energy Incentives (Version 2)
 summary: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
   quantitative spreadsheet by location.
 url: GET /api/energy-incentives/v2/dsire


### PR DESCRIPTION
@jduckworth, @PjEdwards: I tweaked the energy incentives v1 docs a bit to clarify the deprecation (since there were some leftover notes still saying it was the current version) and distinguish between the two versions (since they both had the same titles).

You can see the change on this pull request. I'm going to go ahead and send it live, but feel free to make any further tweaks, if you'd like.