### PR TITLE
Fix Energy Incentives URL

### DIFF
--- a/source/docs/electricity/energy-incentives-v2.md.erb
+++ b/source/docs/electricity/energy-incentives-v2.md.erb
@@ -2,7 +2,7 @@
 title: Energy Incentives (Version 2)
 summary: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
   quantitative spreadsheet by location.
-url: GET /api/energy_incentives/v2/dsire
+url: /api/energy_incentives/v2/dsire
 
 ---
 

--- a/source/docs/electricity/energy-incentives-v2.md.erb
+++ b/source/docs/electricity/energy-incentives-v2.md.erb
@@ -2,7 +2,7 @@
 title: Energy Incentives (Version 2)
 summary: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
   quantitative spreadsheet by location.
-url: GET /api/energy-incentives/v2/dsire
+url: GET /api/energy_incentives/v2/dsire
 
 ---
 


### PR DESCRIPTION
I noticed the given link with a `-` is broken and that the API uses an `_`.

Also the GET HTTP verb was mistakenly in the url causing links to look like

![image](https://cloud.githubusercontent.com/assets/2244895/12212409/fcdb9b20-b61e-11e5-8968-39eb9a975998.png)
