### PR TITLE
Fix the URLs in the dsire energy incentives docs

### DIFF
--- a/source/docs/electricity/energy-incentives-v2.md.erb
+++ b/source/docs/electricity/energy-incentives-v2.md.erb
@@ -2,7 +2,7 @@
 title: Energy Incentives (Version 2)
 summary: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
   quantitative spreadsheet by location.
-url: GET /api/energy-incentives/v2/dsire
+url: /api/energy-incentives/v2/dsire
 
 ---
 
@@ -377,7 +377,7 @@ The response is composed of service-related informational fields and the results
 
 ### XML Output Format (results truncated)
 
-<pre>GET <a href="/api/energy-incentives/v1.xml?api_key=DEMO_KEY&amp;lat=42&amp;lon=-102&amp;category=solar_technologies,biomass&amp;technology=solar_space_heat"><%= current_page.data.url %>.xml?api_key=DEMO_KEY&amp;lat=42&amp;lon=-102&amp;category=biomass&amp;technology=biomass</a></pre>
+<pre>GET <a href="<%= current_page.data.url %>.xml?api_key=DEMO_KEY&amp;lat=42&amp;lon=-102&amp;category=solar_technologies,biomass&amp;technology=solar_space_heat"><%= current_page.data.url %>.xml?api_key=DEMO_KEY&amp;lat=42&amp;lon=-102&amp;category=biomass&amp;technology=biomass</a></pre>
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
As discussed with Rob, there were some URL issues in the docs on this page. 