### PR TITLE
Fix outage dates and add times.

### DIFF
--- a/source/2017-01-outage.md
+++ b/source/2017-01-outage.md
@@ -1,4 +1,8 @@
-There will be a **partial outage** for some of our APIs from January 14, 2016 - January 15, 2016. The affected APIs are:
+---
+alias: 2016-01-outage/
+---
+
+There will be a **partial outage** for some of our APIs from Saturday, January 14, 2017 - Monday, January 16, 2017. The affected APIs are:
 
 - Buildings - Standard Work Specifications
 - Electricity - Energy Incentives
@@ -11,5 +15,7 @@ There will be a **partial outage** for some of our APIs from January 14, 2016 - 
 - Wind - Wind Toolkit Data Downloads
 
 Other APIs should not be affected. We apologize for the inconvenience!
+
+For the affected APIs, we expect the downtime to begin at 8AM ET, Saturday, January 14, 2017. We expect everything to be back by 8AM ET, Monday, January 16, 2017.
 
 [Contact us](/contact/) with any questions, or follow [@NRELdev](https://twitter.com/NRELdev) for updates.

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -35,7 +35,7 @@
   <body class="<%= page_classes %>">
     <%= partial("layouts/header") %>
     <div class="alert alert-danger">
-      There will be a <strong>partial outage</strong> for some of our APIs from January 14, 2016 - January 15, 2016. <a href="/2016-01-outage/">Read more...</a>
+      There will be a <strong>partial outage</strong> for some of our APIs from Saturday, January 14, 2017 - Monday, January 16, 2017. <a href="/2017-01-outage/">Read more...</a>
     </div>
     <%= yield %>
     <%= partial("layouts/edit_me") %>


### PR DESCRIPTION
So, um, I announced the outage as happening in 2016, not 2017. Whoops!

I also added the specific times, and also clarified the ending date (since it could be Monday at 8AM, not Sunday).

![giphy](https://cloud.githubusercontent.com/assets/12112/21872696/405fcb5c-d827-11e6-9e5c-9fd06fe5e870.gif)
