### PR TITLE
move definitions to spec file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,3 @@
 
 # NPM
 /node_modules
-
-# IDEs
-.idea

--- a/source/docs/partnering/experts/spec.yml
+++ b/source/docs/partnering/experts/spec.yml
@@ -146,9 +146,3 @@ definitions:
       resultset:
         type: object
         $ref: "#/definitions/expert"
-#  expert_response:
-#    type: object
-#    $ref: "../definitions/expert.yml#/expert_response"
-#  experts_response:
-#    type: object
-#    $ref: "../definitions/expert.yml#/experts_response"

--- a/source/docs/partnering/experts/spec.yml
+++ b/source/docs/partnering/experts/spec.yml
@@ -65,9 +65,90 @@ paths:
           schema:
             $ref: "#/definitions/expert_response"
 definitions:
-  expert_response:
+  metadata:
     type: object
-    $ref: "../definitions/expert.yml#/expert_response"
+    properties:
+      version:
+        type: string
+        example: 1.0
+  errors:
+    type: array
+    items:
+      type: string
+  expert:
+    type: object
+    properties:
+      uuid:
+        type: string
+        example: dc56d205-4ddf-46d4-bcd6-93ddc7fea84a
+      first_name:
+        type: string
+        example: Daniel
+      last_name:
+        type: string
+        example: Abraham
+      lab:
+        type: string
+        example: Argonne National Laboratory
+      avatar:
+        type: string
+        example: https://www.labpartnering.org/experts/dc56d205-4ddf-46d4-bcd6-93ddc7fea84a/avatar
+      links:
+        type: object
+        properties:
+          self:
+            type: string
+            example: https://developer.nrel.gov/api/lps/v1/experts/dc56d205-4ddf-46d4-bcd6-93ddc7fea84a
+      bio:
+        type: string
+        example: He is well known for his expertise in the field of lithium batteries at Argonne National Laboratory. Since graduating with a doctorate in metallurgical engineering from the University of Illinois at Urbana-Champaign
+    #    specialties:
+    #      type: array
+    #    technologies:
+    #      type: array
+    required:
+    - uuid
+    - first_name
+    - last_name
+    - lab
+    - bio
+  experts:
+    type: array
+    items:
+      $ref: "#/definitions/expert"
   experts_response:
     type: object
-    $ref: "../definitions/expert.yml#/experts_response"
+    properties:
+      metadata:
+        type: object
+        $ref: "#/definitions/metadata"
+      errors:
+        type: object
+        $ref: "#/definitions/errors"
+      resultset:
+        type: object
+        properties:
+          count:
+            type: integer
+            example: 20
+          result:
+            type: object
+            $ref: "#/definitions/experts"
+  expert_response:
+    type: object
+    properties:
+      metadata:
+        type: object
+        $ref: "#/definitions/metadata"
+      errors:
+        type: object
+        $ref: "#/definitions/errors"
+      resultset:
+        type: object
+        $ref: "#/definitions/expert"
+#  expert_response:
+#    type: object
+#    $ref: "../definitions/expert.yml#/expert_response"
+#  experts_response:
+#    type: object
+#    $ref: "../definitions/expert.yml#/experts_response"

--- a/source/docs/partnering/experts/spec.yml
+++ b/source/docs/partnering/experts/spec.yml
@@ -56,8 +56,7 @@ paths:
       parameters:
       - in: path
         name: expert_uuid
-        schema:
-          type: string
+        type: string
         required: true
         description: UUID of the national laboratory expert to get
       responses:

--- a/source/docs/partnering/experts/spec.yml
+++ b/source/docs/partnering/experts/spec.yml
@@ -43,7 +43,6 @@ paths:
           - srnl
           - tjnaf
           - y12
-
         required: false
         description: National laboratory alias, when not specified all experts are returnd from all labs
       responses:

--- a/source/docs/partnering/labs/spec.yml
+++ b/source/docs/partnering/labs/spec.yml
@@ -29,8 +29,7 @@ paths:
       parameters:
       - in: path
         name: lab_uuid
-        schema:
-          type: string
+        type: string
         required: true
         description: UUID of the national laboratory to get
       responses:
@@ -39,12 +38,6 @@ paths:
           schema:
             $ref: "#/definitions/lab_response"
 definitions:
-  laboratories:
-    type: object
-    $ref: "../definitions/lab.yml#/laboratories"
-  lab:
-    type: object
-    $ref: "../definitions/lab.yml#/lab"
   lab_response:
     type: object
     $ref: "../definitions/lab.yml#/lab_response"

--- a/source/docs/partnering/labs/spec.yml
+++ b/source/docs/partnering/labs/spec.yml
@@ -38,9 +38,112 @@ paths:
           schema:
             $ref: "#/definitions/lab_response"
 definitions:
-  lab_response:
+  metadata:
     type: object
-    $ref: "../definitions/lab.yml#/lab_response"
+    properties:
+      version:
+        type: string
+        example: 1.0
+  errors:
+    type: array
+    items:
+      type: string
+  lab:
+    type: object
+    properties:
+      uuid:
+        type: string
+        example: 243e2911-3e43-40ba-b08b-418b21d23d38
+      name:
+        type: string
+        example: Ames Laboratory
+      tto_url:
+        type: string
+        example: http://www.techtransfer.iastate.edu/
+      contact_us_email:
+        type: string
+        example: contactus@iastate.edu
+      avatar:
+        type: string
+        example: developer.nrel.gov/labs/41665339-db90-4067-8f1a-e93567208f39/avatar_uuid
+      links:
+        type: object
+        properties:
+          self:
+            type: string
+            example: developer.nrel.gov/api/v1/labs/41665339-db90-4067-8f1a-e93567208f39
+      alias:
+        type: string
+        example: ames
+      description:
+        type: string
+        example: Ames Laboratory, a U.S. Department of Energy Office of Science National Laboratory managed by Iowa State University, creates materials and energy solutions. With its roots in the Manhattan Project, Ames Laboratory today seeks solutions to energy-related problems of national importance through the
+      contact_email:
+        type: string
+        example: ameslps@ameslab.gov
+      contact_name:
+        type: string
+        example: Beth Pieper
+      location:
+        type: string
+        example: Ames, Iowa
+      experts:
+        type: array
+        items:
+          properties:
+            uuid:
+              type: string
+              example: fb5af872-beb8-4323-acb4-d072c512561d
+            first_name:
+              type: string
+              example: Iver
+            last_name:
+              type: string
+              example: Anderson
+            avatar:
+              type: string
+              example: https://www.labpartnering.org/experts/fb5af872-beb8-4323-acb4-d072c512561d/avatar
+            links:
+              type: object
+              properties:
+                self:
+                  type: string
+                  example: https://developer.nrel.gov/api/lps/v1/experts/fb5af872-beb8-4323-acb4-d072c512561d
+    required:
+    - uuid
+    - name
+    - alias
+  laboratories:
+    type: array
+    items:
+      $ref: "#/definitions/lab"
   labs_response:
     type: object
-    $ref: "../definitions/lab.yml#/labs_response"
+    properties:
+      metadata:
+        type: object
+        $ref: "#/definitions/metadata"
+      errors:
+        type: object
+        $ref: "#/definitions/errors"
+      resultset:
+        type: object
+        $ref: "#/definitions/laboratories"
+  lab_response:
+    type: object
+    properties:
+      metadata:
+        type: object
+        $ref: "#/definitions/metadata"
+      errors:
+        type: object
+        $ref: "#/definitions/errors"
+      resultset:
+        type: object
+        $ref: "#/definitions/lab"
+#  lab_response:
+#    type: object
+#    $ref: "../definitions/lab.yml#/lab_response"
+#  labs_response:
+#    type: object
+#    $ref: "../definitions/lab.yml#/labs_response"

--- a/source/docs/partnering/labs/spec.yml
+++ b/source/docs/partnering/labs/spec.yml
@@ -141,9 +141,3 @@ definitions:
       resultset:
         type: object
         $ref: "#/definitions/lab"
-#  lab_response:
-#    type: object
-#    $ref: "../definitions/lab.yml#/lab_response"
-#  labs_response:
-#    type: object
-#    $ref: "../definitions/lab.yml#/labs_response"

--- a/source/docs/partnering/patents/spec.yml
+++ b/source/docs/partnering/patents/spec.yml
@@ -29,8 +29,7 @@ paths:
       parameters:
       - in: path
         name: patent_number
-        schema:
-          type: string
+        type: string
         required: true
         description: Number of the national laboratory patent to get
       responses:

--- a/source/docs/partnering/patents/spec.yml
+++ b/source/docs/partnering/patents/spec.yml
@@ -5,7 +5,7 @@ info:
   description: |-
     A collection of APIs providing data about national laboratorty patents related to associated with the Department of Energy's (DOE) Lab Partnering Service (LPS).
 schemes:
-  - https
+- https
 basePath: /api/lps/v1
 securityDefinitions:
   api_key:
@@ -13,7 +13,7 @@ securityDefinitions:
     name: api_key
     in: query
 security:
-  - api_key: []
+- api_key: []
 paths:
   /patents:
     get:
@@ -38,9 +38,137 @@ paths:
           schema:
             $ref: "#/definitions/patent_response"
 definitions:
+  patent:
+    type: object
+    properties:
+      number:
+        type: string
+        example: 9,945,585
+      title:
+        type: string
+        example: Systems and methods for direct thermal receivers using near blackbody configurations
+      filed_on:
+        type: string
+        format: date
+        example: '2015-05-15'
+      issued_on:
+        type: string
+        format: date
+        example: '2018-04-17'
+        description: if issued_on is null the patent is in the application process
+      document_number:
+        type: string
+        example: 20150330668
+      document_published_on:
+        type: string
+        format: date
+        example: '2015-11-19'
+      abstract:
+        type: string
+        example: An aspect of the present disclosure is a receiver for receiving radiation from a heliostat array that includes at least one external panel configured to form an internal cavity and an open face. The open face is positioned substantially perpendicular to a longitudinal axis and forms an entrance to the internal cavity. The receiver also includes at least one internal panel positioned within the cavity and aligned substantially parallel to the longitudinal axis, and the at least one internal panel includes at least one channel configured to distribute a heat transfer medium.
+      government_interest:
+        type: string
+        example: CONTRACTUAL ORIGIN The United States Government has rights in this invention under Contract No. DE-AC36-08GO28308 between the United States Department of Energy and the Alliance for Sustainable Energy, LLC, the manager and operator of the National Renewable Energy Laboratory.
+      inventors:
+        type: array
+        items:
+          properties:
+            name:
+              type: string
+              example: Michael Wagner
+            location:
+              type: string
+              example: Highlands Ranch, CO, US
+      labs:
+        type: array
+        items:
+          properties:
+            uuid:
+              type: string
+              example: e2af34a8-8b90-4726-9edf-fa75fede52e8
+            name:
+              type: string
+              example: National Renewable Energy Laboratory
+            tto_url:
+              type: string
+              example: https://www.nrel.gov/workingwithus/technology-transfer.html
+            contact_us_email:
+              type: string
+              example: Eric.Payne@nrel.gov
+            links:
+              type: array
+              items:
+                properties:
+                  self:
+                    type: string
+                    example: "https://developer.nrel.gov/api/lps/v1/labs/e2af34a8-8b90-4726-9edf-fa75fede52e8"
+      links:
+        type: object
+        properties:
+          self:
+            type: string
+            example: https://developer.nrel.gov/api/lps/v1/patents/20010000475
+          html:
+            type: string
+            example: https://www.labpartnering.org/patents/9,945,585.html
+    required:
+    - number
+    - title
+    - abstract
+  patents:
+    type: array
+    items:
+      $ref: "#/definitions/patent"
+  metadata:
+    type: object
+    properties:
+      version:
+        type: string
+        example: 1.0
+  errors:
+    type: array
+    items:
+      type: string
   patent_response:
     type: object
-    $ref: "../definitions/patent.yml#/patent_response"
+    properties:
+      metadata:
+        type: object
+        $ref: "#/definitions/metadata"
+      errors:
+        type: object
+        $ref: "#/definitions/errors"
+      resultset:
+        type: object
+        $ref: "#/definitions/patent"
   patents_response:
     type: object
-    $ref: "../definitions/patent.yml#/patents_response"
+    properties:
+      metadata:
+        type: object
+        $ref: "#/definitions/metadata"
+      errors:
+        type: object
+        $ref: "#/definitions/errors"
+      resultset:
+        type: object
+        properties:
+          total:
+            type: integer
+            example: 20000
+            description: Total number of patents which meet the search criteria
+          count:
+            type: integer
+            example: 20
+            description: The number of patents in a single response
+          number:
+            type: integer
+            example: 1
+            description: The current page number of paginated responses
+          pages:
+            type: integer
+            example: 39
+            description: The total number of pages in the paginated responses
+          result:
+            type: object
+            $ref: "#/definitions/patents"


### PR DESCRIPTION
to move past this first deployment of documentation I simplified but moving definitions to the spec.yml in the specific directory.