### PR TITLE
Deprecate DSIRE Incentives API

### DIFF
--- a/source/docs/electricity/energy-incentives-v2.html.md.erb
+++ b/source/docs/electricity/energy-incentives-v2.html.md.erb
@@ -11,7 +11,7 @@ deprecated: true
 <%= current_page.data.summary %>
 
 <div class="alert alert-danger">
-  <p>The DSIRE database, which is managed by the the North Carolina Solar Center and provides the quantitative data that support this web service, is no longer being updated, maintained, or supported. This service will remain active for archival purposes only.</p>
+  <p>The DSIRE database, which is managed by the the North Carolina Solar Center and provides the quantitative data that support this web service, is no longer being updated, maintained. The DSIRE database was maintained through the end of 2017. This service will remain active for archival purposes only.</p>
 </div>
 
 <ul id="toc"></ul>

--- a/source/docs/electricity/energy-incentives-v2.html.md.erb
+++ b/source/docs/electricity/energy-incentives-v2.html.md.erb
@@ -1,15 +1,18 @@
 ---
 title: Energy Incentives (Version 2)
 summary: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
-  database by location. The data served by this service is synchronized with the DSIRE data nightly.
+  database by location.
 url: /api/energy_incentives/v2/dsire
+deprecated: true
 
 ---
 
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 <%= current_page.data.summary %>
 
-This is the current version of the energy incentives API. Previous versions have been deprecated and its users are encouraged to migrate to this newly enhanced version.
+<div class="alert alert-danger">
+  <p>The DSIRE database, which is managed by the the North Carolina Solar Center and provides the quantitative data that support this web service, is no longer being updated, maintained, or supported. This service will remain active for archival purposes only.</p>
+</div>
 
 <ul id="toc"></ul>
 

--- a/source/docs/electricity/energy-incentives-v2.html.md.erb
+++ b/source/docs/electricity/energy-incentives-v2.html.md.erb
@@ -1,6 +1,6 @@
 ---
-title: Energy Incentives (Version 2)
-summary: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
+title: Energy Incentives (Version 2 - Deprecated)
+summary: Deprecated: This service lists the incentives found in the [DSIRE](http://www.dsireusa.org/)
   database by location.
 url: /api/energy_incentives/v2/dsire
 deprecated: true


### PR DESCRIPTION
The syncing service between this API and the DSIRE DB has been failing regularly for a while now. Staff at NCCECT indicate that it was last funded in 2017 and the APIs are no longer being maintained.. basically it will never get fixed and the data is rapidly falling out of date. 