### PR TITLE
Update "limit" documentation for alt fuel stations API

### DIFF
--- a/source/docs/transportation/alt-fuel-stations-v1/all.html.md.erb
+++ b/source/docs/transportation/alt-fuel-stations-v1/all.html.md.erb
@@ -35,16 +35,16 @@ The following query parameters may be passed in the request to control the outpu
       <td class="doc-parameter-required">No</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
-          <strong>Type:</strong> integer
+          <strong>Type:</strong> integer or string
         </div>
         <div class="doc-parameter-value-field">
           <strong>Default:</strong> all
         </div>
         <div class="doc-parameter-value-field">
-          <strong>Minimum:</strong> <i>1</i>
+          <strong>Range:</strong> <em>0</em> to <em>200</em>, or <em>all</em>
         </div>
       </td>
-      <td class="doc-parameter-description">The maximum number of results to return. If not specified, all results will be returned. Note: Since results are returned in no specific order, this has limited use, other than for testing purposes.</td>
+      <td class="doc-parameter-description">The maximum number of results to return. An explicit limit of up to 200 may be passed in, or the special <code>all</code> string may be passed in to return all results.</td>
     </tr>
   </tbody>
 </table>

--- a/source/docs/transportation/alt-fuel-stations-v1/nearby-route.html.md.erb
+++ b/source/docs/transportation/alt-fuel-stations-v1/nearby-route.html.md.erb
@@ -111,16 +111,16 @@ LINESTRING(-74.0 40.7, -87.63 41.87, -104.98 39.76)
       <td class="doc-parameter-required">No</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
-          <strong>Type:</strong> integer
+          <strong>Type:</strong> integer or string
         </div>
         <div class="doc-parameter-value-field">
           <strong>Default:</strong> all
         </div>
         <div class="doc-parameter-value-field">
-          <strong>Minimum:</strong> <i>1</i>
+          <strong>Range:</strong> <em>0</em> to <em>200</em>, or <em>all</em>
         </div>
       </td>
-      <td class="doc-parameter-description">The maximum number of results to return. If not specified, all results will be returned.</td>
+      <td class="doc-parameter-description">The maximum number of results to return. An explicit limit of up to 200 may be passed in, or the special <code>all</code> string may be passed in to return all results.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">offset</th>

--- a/source/docs/transportation/alt-fuel-stations-v1/nearest.html.md.erb
+++ b/source/docs/transportation/alt-fuel-stations-v1/nearest.html.md.erb
@@ -110,16 +110,16 @@ The following query parameters may be passed in the request to control the outpu
       <td class="doc-parameter-required">No</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
-          <strong>Type:</strong> integer
+          <strong>Type:</strong> integer or string
         </div>
         <div class="doc-parameter-value-field">
           <strong>Default:</strong> 20
         </div>
         <div class="doc-parameter-value-field">
-          <strong>Minimum:</strong> <i>1</i>
+          <strong>Range:</strong> <em>0</em> to <em>200</em>, or <em>all</em>
         </div>
       </td>
-      <td class="doc-parameter-description">The maximum number of results to return.</td>
+      <td class="doc-parameter-description">The maximum number of results to return. An explicit limit of up to 200 may be passed in, or the special <code>all</code> string may be passed in to return all results.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">offset</th>


### PR DESCRIPTION
- The "all" option is now available on the "nearest" endpoint.
- Better document the explicit "all" option across all the endpoints.
- Update to indicate that `0` is now the lower bound value (this has been the case for a while, but the docs were never updated).