### PR TITLE
Bumps reference to total download size to match real

### DIFF
--- a/source/docs/solar/nsrdb/guide.html.md.erb
+++ b/source/docs/solar/nsrdb/guide.html.md.erb
@@ -20,7 +20,7 @@ For downloading directly via CSV there are separate rate limits. This is due to 
 > 1 request per second
 > 20 requests in process at once
 
-The size limit per each single request is determined by the number of total attributes in each request. The maximum weight of each request is **1000000**. The calculation for determining the weight of each request is:
+The size limit per each single request is determined by the number of total attributes in each request. The maximum weight of each request is **5000000**. The calculation for determining the weight of each request is:
 
 > <em>site-count\*attribute-count\*year-count\*data-intervals-per-year</em>
 

--- a/source/docs/wave/guide.html.md.erb
+++ b/source/docs/wave/guide.html.md.erb
@@ -20,7 +20,7 @@ For downloading directly via CSV there are separate rate limits. This is due to 
 > 1 request per second
 > 20 requests in process at once
 
-The size limit per each single request is determined by the number of total attributes in each request. The maximum weight of each request is **1000000**. The calculation for determining the weight of each request is:
+The size limit per each single request is determined by the number of total attributes in each request. The maximum weight of each request is **5000000**. The calculation for determining the weight of each request is:
 
 > <em>site-count\*attribute-count\*year-count\*data-intervals-per-year</em>
 

--- a/source/docs/wind/wind-toolkit/guide.html.md.erb
+++ b/source/docs/wind/wind-toolkit/guide.html.md.erb
@@ -20,7 +20,7 @@ For downloading directly via CSV there are separate rate limits. This is due to 
 > 1 request per second
 > 20 requests in process at once
 
-The size limit per each single request is determined by the number of total attributes in each request. The maximum weight of each request is **1000000**. The calculation for determining the weight of each request is:
+The size limit per each single request is determined by the number of total attributes in each request. The maximum weight of each request is **5000000**. The calculation for determining the weight of each request is:
 
 > <em>site-count\*attribute-count\*year-count\*data-intervals-per-year</em>
 


### PR DESCRIPTION
This is a trivial text change. Going to self merge due to impending webinar.