### PR TITLE
Update virtual buoy summary documentation

### DIFF
--- a/source/docs/wave/virtual-buoy/index.html.md.erb
+++ b/source/docs/wave/virtual-buoy/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Virtual Buoy Data Downloads
-summary: Freely available downloads of Vritual Buoy Wave Datasets.
+summary: Freely available downloads of Virtual Buoy Wave Datasets.
 
 ---
 


### PR DESCRIPTION
Fixes the typo "vritual" to "virtual"