### PR TITLE
Fix type of `outputs` in response

### DIFF
--- a/source/docs/solar/pvwatts/v8.html.md.erb
+++ b/source/docs/solar/pvwatts/v8.html.md.erb
@@ -560,7 +560,7 @@ The response is composed of service-related informational fields and the results
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">outputs</th>
-      <td class="doc-parameter-value"><strong>Type:</strong> string</td>
+      <td class="doc-parameter-value"><strong>Type:</strong> collection</td>
       <td class="doc-parameter-description">
         The data outputs from the simulation. (see <a href="#output-fields">output fields</a> for more detail)
       </td>


### PR DESCRIPTION
The `outputs` result shape has not changed since V6 of the API, so it the documentation should probably still state "Type: collection" not string.