### PR TITLE
Update allowed years in `psm3-2-2-download` and `psm3-5min-download`

### DIFF
--- a/source/docs/solar/nsrdb/psm3-2-2-download.html.md.erb
+++ b/source/docs/solar/nsrdb/psm3-2-2-download.html.md.erb
@@ -69,7 +69,7 @@ _NOTE: when using POST to submit a request the api_key must still be included as
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field"><strong>Type:</strong> comma delimited string array</div>
         <div class="doc-parameter-value-field"><strong>Default:</strong> None</div>
-        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>2021</em></div>
+        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021</em></div>
       </td>
       <td class="doc-parameter-description">The year(s) for which data should be extracted. (more years coming soon)</td>
     </tr>

--- a/source/docs/solar/nsrdb/psm3-5min-download.html.md.erb
+++ b/source/docs/solar/nsrdb/psm3-5min-download.html.md.erb
@@ -69,7 +69,7 @@ _NOTE: when using POST to submit a request the api_key must still be included as
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field"><strong>Type:</strong> comma delimited string array</div>
         <div class="doc-parameter-value-field"><strong>Default:</strong> None</div>
-        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>2018, 2019, 2020</em></div>
+        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>2018, 2019, 2020, 2021</em></div>
       </td>
       <td class="doc-parameter-description">The year(s) for which data should be extracted.</td>
     </tr>


### PR DESCRIPTION
Howdy, just updating the list of allowed years for the PSM3 endpoints.  

Also, `tmy-2021` and its `t*y-2021` brethren aren't available yet, right?