### PR TITLE
Remove Utilities from Transportation Laws and Incentives

### DIFF
--- a/source/docs/transportation/transportation-incentives-laws-v1/spec.yml
+++ b/source/docs/transportation/transportation-incentives-laws-v1/spec.yml
@@ -119,7 +119,7 @@ paths:
       - in: query
         description: 'Search by the law type. A single type, or a comma-separate list
           of multiple types, may be given. Values are as follows: ''STATEINC'' for
-          State Incentives, ''UPINC '' for Utility/Private Incentives, ''LAWREG''
+          State Incentives, ''LAWREG''
           for Laws and Regulations, ''INC'' for Incentives, ''PROG'' for Programs,
           ''LUP'' for Last Updated, ''OVIEW'' for Overview, and ''HILITE'' for Highlights.'
         name: law_type
@@ -335,8 +335,7 @@ definitions:
       type:
         type: string
         description: 'The category that the incentive/law/regulation falls under,
-          described below: -State Incentives, -Laws and Regulations, -Utility/Private
-          Incentives'
+          described below: -State Incentives, -Laws and Regulations'
       agency:
         type: string
         description: The agency with primary responsibility for federal incentives/regulations.

--- a/source/docs/transportation/transportation-incentives-laws-v1/spec.yml
+++ b/source/docs/transportation/transportation-incentives-laws-v1/spec.yml
@@ -119,8 +119,7 @@ paths:
       - in: query
         description: 'Search by the law type. A single type, or a comma-separate list
           of multiple types, may be given. Values are as follows: ''STATEINC'' for
-          State Incentives, ''LAWREG''
-          for Laws and Regulations, ''INC'' for Incentives, ''PROG'' for Programs,
+          State Incentives, ''LAWREG'' for Laws and Regulations, ''INC'' for Incentives, ''PROG'' for Programs,
           ''LUP'' for Last Updated, ''OVIEW'' for Overview, and ''HILITE'' for Highlights.'
         name: law_type
         required: false


### PR DESCRIPTION
## What is this? 

This updates the API documentation for Utilities.

This removes ' 'UPINC ' for Utility/Private Incentives,  ' from the description of the law_type parameter; 

And removes ' , -Utility/Private Incentives ' from the Model description of a Successful request.