### PR TITLE
Update REopt API documentation page

### DIFF
--- a/source/docs/energy-optimization/reopt/index.html.md.erb
+++ b/source/docs/energy-optimization/reopt/index.html.md.erb
@@ -1,19 +1,18 @@
 ---
 title: REopt™ API
-summary: The REopt™ Application Programming Interface provides programmatic access to [REopt web tool](https://reopt.nrel.gov/tool) back-end. REopt is a techno-economic decision support platform is used by NREL researchers to optimize energy systems for buildings, campuses, communities, microgrids, and more. REopt recommends the optimal mix of renewable energy, conventional generation, and energy storage technologies to meet cost savings, resilience, and energy performance goals.
+summary: The REopt™ Application Programming Interface provides programmatic access to NREL's REopt tool. REopt is a techno-economic decision support platform is used by NREL researchers to optimize energy systems for buildings, campuses, communities, microgrids, and more. REopt recommends the optimal mix of renewable energy, conventional generation, and energy storage technologies to meet cost savings, resilience, and energy performance goals.
 ---
 
 # <%= current_page.data.title %>
 <%= current_page.data.summary %>
 
-General information related to REopt can be found at [https://reopt.nrel.gov](https://reopt.nrel.gov)
-
-For user support please use the discussion board at [https://github.com/NREL/REopt-API-Analysis/discussions](https://github.com/NREL/REopt-API-Analysis/discussions)
-
-Users can find more information on the REopt API in the [Analysis Wiki](https://github.com/NREL/REopt-API-Analysis/wiki).
-
-API developers can find useful information in the [API Wiki](https://github.com/NREL/REopt_API/wiki)
-
-There is also a [REopt Julia package](https://nrel.github.io/REopt.jl/dev/) (which will be the API back-end in v3).
+<ul>
+    <li>General information related to REopt can be found at the <a href="https://www.nrel.gov/reopt">REopt Platform home page</a> (https://www.nrel.gov/reopt).</li>
+    <li>The web version of REopt can be accessed at the <a href="https://reopt.nrel.gov">REopt Web Tool page</a> (https://reopt.nrel.gov).</li>
+    <li>For user support please use the <a href="https://github.com/NREL/REopt-Analysis-Scripts/discussions">REopt User Forum</a> (https://github.com/NREL/REopt-Analysis-Scripts/discussions).</li>
+    <li>For help calling the API or using REopt.jl, see the <a href="https://github.com/NREL/REopt-Analysis-Scripts/wiki">REopt Analysis Wiki</a> (https://github.com/NREL/REopt-Analysis-Scripts/wiki).</li>
+    <li>API developers can find development tips in the <a href="https://github.com/NREL/REopt_API/wiki">REopt API Wiki</a> (https://github.com/NREL/REopt_API/wiki).</li>
+    <li>REopt is also available as the <a href="https://nrel.github.io/REopt.jl/dev">REopt.jl Julia package</a> (https://nrel.github.io/REopt.jl/dev) which is the engine of the REopt API starting in V3, and can be used directly in a Julia environment.</li>
+</ul>
 
 <%= partial("layouts/child_links") %>

--- a/source/docs/energy-optimization/reopt/v1.html.md.erb
+++ b/source/docs/energy-optimization/reopt/v1.html.md.erb
@@ -1,15 +1,11 @@
 ---
 title: REopt API V1
-summary: Version 1 is the previous version of the REopt API. It is recommended to use Version 2 instead because it has updated default values.
+summary: V1 and V2 of the API are decommissioned, as of 3/31/2024. See V3 (stable).
 url: GET /api/reopt/v1
 sort_value: "0"
-alias: docs/energy-optimization/reopt-v1/
+deprecated: true
 ---
 
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 
-# User Documentation
-Documentation for using the REopt API is housed at [https://github.com/NREL/REopt-API-Analysis/wiki](https://github.com/NREL/REopt-API-Analysis/wiki)
-
-# Developer Documentation
-Documentation for developing the REopt API is housed at [https://github.com/NREL/REopt_API/wiki](https://github.com/NREL/REopt_API/wiki)
+V1 and V2 of the API are decommissioned, as of 3/31/2024

--- a/source/docs/energy-optimization/reopt/v2.html.md.erb
+++ b/source/docs/energy-optimization/reopt/v2.html.md.erb
@@ -1,33 +1,11 @@
 ---
 title: REopt API V2
-summary: Version 2 is the stable version of the REopt API. Version 2 provides the same cabilities as Version 1 but wih updated default values.
-url: GET /api/reopt/v2 or /api/reopt/stable
+summary: V1 and V2 of the API are decommissioned, as of 3/31/2024. See V3 (stable).
+url: GET /api/reopt/v2
 sort_value: "0"
+deprecated: true
 ---
 
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 
-# User Documentation
-The difference between v1 and v2 is in some default cost assumptions:
-
-- Discount rate from 8.3% to 5.64%
-- Electricity cost escalation rate from 2.3% to 1.9%
-- PV System capital cost ($/kW) from $1600 to $1592
-- PV O&M cost ($/kW/yr) from $16 to $17
-- Battery Energy capacity cost ($/kWh) from $420 to $388
-- Battery Power capacity cost ($/kW AC) from $840 to $775
-- 10 yr Battery Energy capacity replacement cost ($/kWh) from $200 to $220
-- 10 yr Battery Power capacity replacement cost ($/kW AC) from $410 to $440
-- Wind O&M cost ($/kW/yr) from $40 to $35
-- Wind System Capital costs ($/kW)
-
-    - Residential (0-20 kW) from $11950 to $5675
-    - Commercial (21-100 kW) from $7390 to $4300
-    - Midsize (101-999 kW) from $4440 to $2766
-    - Large (>=1000 kW) from $3450 to $2239
-
-These changes in default values can result in different results from v2 compared to v1 (given the same inputs that were used with v1).
-These default values relect the latest economic information available.
-
-# Developer Documentation
-Documentation for developing the REopt API is housed at [https://github.com/NREL/REopt_API/wiki](https://github.com/NREL/REopt_API/wiki)
+V1 and V2 of the API are decommissioned, as of 3/31/2024

--- a/source/docs/energy-optimization/reopt/v3.html.md.erb
+++ b/source/docs/energy-optimization/reopt/v3.html.md.erb
@@ -1,15 +1,17 @@
 ---
 title: REopt API V3
-summary: Version 3 is the development version of the REopt API. It uses the REopt Julia package as it's back-end.
-url: GET /api/reopt/dev
+summary: Version 3 is the stable version of the REopt API. It uses the REopt Julia package as its optimization engine.
+url: GET /api/reopt/stable
 sort_value: "0"
 ---
 
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 
-Version 3 of the REopt API is currently under development. 
+Version 3 of the REopt API is currently the stable version of the API. 
 # User Documentation
-The inputs and outputs for optimization jobs are revised in v3 for clarity and ease-of-use. Please see [https://github.com/NREL/REopt_API/wiki/new-job-endpoint](https://github.com/NREL/REopt_API/wiki/new-job-endpoint) for more information.
+The inputs and outputs for optimization jobs are revised in v3 for clarity and ease-of-use. Please see our [help documentation for creating/converting to V3 inputs .json POST](https://github.com/NREL/REopt-Analysis-Scripts/wiki/3.-V3-input-and-output-changes) for more information. 
+
+The REopt.jl Julia package is used as the optimization engine for the V3 (stable) version of the API. The I/O of the API largely mirrors REopt.jl. You can also access REopt.jl directly in a Julia environment, with documentation about I/O available at [REopt Julia package](https://nrel.github.io/REopt.jl/dev/)
 
 # Developer Documentation
-Information for developers regarding v3 can be found at [https://github.com/NREL/REopt_API/wiki/new-job-endpoint](https://github.com/NREL/REopt_API/wiki/new-job-endpoint)
+Information for developers regarding V3 can be found at [the REopt API GitHub Wiki page](https://github.com/NREL/REopt_API/wiki)


### PR DESCRIPTION
Update REopt API documentation page
- V3 as stable, decommissioned V1 and V2
- Updated links and pointers to I/O docs