### PR TITLE
Change all URLs from http to https

### DIFF
--- a/source/docs/solar/nsrdb/full-disc-download.html.md.erb
+++ b/source/docs/solar/nsrdb/full-disc-download.html.md.erb
@@ -266,7 +266,7 @@ Year,Month,Day,Hour,Minute,Alpha,AOD,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=alpha,aod,ghi,dni,dhi&names=2019&utc=true&leap_day=true&interval=10&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/guide.html.md.erb
+++ b/source/docs/solar/nsrdb/guide.html.md.erb
@@ -39,7 +39,7 @@ In cases where a very large WKT value is required, e.g. downloading the maximum 
 ```python
 import requests
 
-url = "http://developer.nrel.gov/api/solar/psm3-5min-download.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov/api/solar/psm3-5min-download.json?api_key=yourapikeygoeshere"
 
 payload = "names=2012&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed_10m_nwp%2Csurface_air_temperature_nwp&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 
@@ -56,7 +56,7 @@ print(response.text)
 And a CURL example of the same
 
 ```shell
-curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Cache-Control: no-cache" -d 'names=2009&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=user@company.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed_10m_nwp%2Csurface_air_temperature_nwp&wkt=MULTIPOINT(-106.22 32.9741%2C-106.18 32.9741%2C-106.1 32.9741%2C-106.06 32.9741)' "http://developer.nrel.gov/api/solar/psm3-5min-download.json?api_key=yourapikeygoeshere"
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Cache-Control: no-cache" -d 'names=2009&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=user@company.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed_10m_nwp%2Csurface_air_temperature_nwp&wkt=MULTIPOINT(-106.22 32.9741%2C-106.18 32.9741%2C-106.1 32.9741%2C-106.06 32.9741)' "https://developer.nrel.gov/api/solar/psm3-5min-download.json?api_key=yourapikeygoeshere"
 ```
 
 <h2 id="contacts">Contact</h2>

--- a/source/docs/solar/nsrdb/himawari-download.html.md.erb
+++ b/source/docs/solar/nsrdb/himawari-download.html.md.erb
@@ -275,7 +275,7 @@ Year,Month,Day,Hour,Minute,Alpha,AOD,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "wkt=POINT(179.9901 -16.96)&attributes=alpha,aod,ghi,dni,dhi&names=2018&utc=true&leap_day=true&interval=30&email=user@company.com"
 

--- a/source/docs/solar/nsrdb/himawari-tmy-download.html.md.erb
+++ b/source/docs/solar/nsrdb/himawari-tmy-download.html.md.erb
@@ -290,7 +290,7 @@ Year,Month,Day,Hour,Minute,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "wkt=POINT(179.99 -16.96)&attributes=ghi,dni,dhi&names=tdy-2020,tgy-2020,tmy-2020&utc=false&leap_day=true&interval=60&email=user@company.com&full_name=Sample User&affiliation=Test Organization&reason=Researching solar potential in my area&mailing_list=true"
 

--- a/source/docs/solar/nsrdb/himawari7-download.html.md.erb
+++ b/source/docs/solar/nsrdb/himawari7-download.html.md.erb
@@ -275,7 +275,7 @@ Year,Month,Day,Hour,Minute,Alpha,AOD,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "wkt=POINT(179.9901 -16.96)&attributes=alpha,aod,ghi,dni,dhi&names=2011&utc=true&leap_day=true&interval=30&email=user@company.com"
 

--- a/source/docs/solar/nsrdb/meteosat-download.html.md.erb
+++ b/source/docs/solar/nsrdb/meteosat-download.html.md.erb
@@ -258,7 +258,7 @@ Year,Month,Day,Hour,Minute,Wind Speed
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=2012&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed%2Cair_temperature&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 

--- a/source/docs/solar/nsrdb/nsrdb-GOES-aggregated-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-aggregated-v4-0-0-download.html.md.erb
@@ -262,7 +262,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb-GOES-conus-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-conus-v4-0-0-download.html.md.erb
@@ -262,7 +262,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb-GOES-full-disc-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-full-disc-v4-0-0-download.html.md.erb
@@ -262,7 +262,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb-GOES-tmy-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-tmy-v4-0-0-download.html.md.erb
@@ -262,7 +262,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-download.html.md.erb
@@ -265,7 +265,7 @@ Year,Month,Day,Hour,Minute,Alpha,AOD,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=alpha,aod,ghi,dni,dhi&names=2019&utc=true&leap_day=true&interval=10&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-tdy-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-tdy-download.html.md.erb
@@ -265,7 +265,7 @@ Year,Month,Day,Hour,Minute,Alpha,AOD,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=alpha,aod,ghi,dni,dhi&names=2019&utc=true&leap_day=true&interval=10&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-tgy-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-tgy-download.html.md.erb
@@ -265,7 +265,7 @@ Year,Month,Day,Hour,Minute,Alpha,AOD,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=alpha,aod,ghi,dni,dhi&names=2019&utc=true&leap_day=true&interval=10&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-tmy-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-msg-v1-0-0-tmy-download.html.md.erb
@@ -265,7 +265,7 @@ Year,Month,Day,Hour,Minute,Alpha,AOD,GHI,DNI,DHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=alpha,aod,ghi,dni,dhi&names=2019&utc=true&leap_day=true&interval=10&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/solar/nsrdb/nsrdb_data_query.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb_data_query.html.md.erb
@@ -195,7 +195,7 @@ Generated data files are formatted in accordance with the Standard Time Series D
   },
   "outputs": [
     {
-      "apiDocs": "http://developer.nrel.gov/docs/solar/nsrdb/suny_data_download/",
+      "apiDocs": "https://developer.nrel.gov/docs/solar/nsrdb/suny_data_download/",
       "availableYears": [
         "tmy",
         2000,
@@ -225,82 +225,82 @@ Generated data files are formatted in accordance with the Standard Time Series D
         {
           "year": "tmy",
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=tmy&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=tmy&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2000,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2000&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2000&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2001,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2001&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2001&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2002,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2002&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2002&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2003,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2003&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2003&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2004,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2004&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2004&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2005,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2005&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2005&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2006,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2006&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2006&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2007,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2007&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2007&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2008,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2008&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2008&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2009,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2009&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2009&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2010,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2010&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2010&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2011,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2011&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2011&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2012,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2012&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2012&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2013,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2013&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2013&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         },
         {
           "year": 2014,
           "interval": 60,
-          "link": "http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2014&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
+          "link": "https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2014&wkt=POINT%2891.287+23.832%29&interval=60&api_key=yourapikey&email=youremail"
         }
       ]
     }
@@ -321,7 +321,7 @@ Generated data files are formatted in accordance with the Standard Time Series D
   </inputs>
   <outputs type="array">
     <output>
-      <apiDocs>http://developer.nrel.gov/docs/solar/nsrdb/suny_data_download/</apiDocs>
+      <apiDocs>https://developer.nrel.gov/docs/solar/nsrdb/suny_data_download/</apiDocs>
       <availableYears type="array">
         <availableYear>tmy</availableYear>
         <availableYear type="integer">2000</availableYear>
@@ -351,82 +351,82 @@ Generated data files are formatted in accordance with the Standard Time Series D
         <link>
           <year>tmy</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=tmy&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=tmy&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2000</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2000&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2000&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2001</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2001&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2001&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2002</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2002&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2002&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2003</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2003&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2003&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2004</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2004&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2004&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2005</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2005&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2005&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2006</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2006&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2006&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2007</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2007&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2007&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2008</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2008&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2008&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2009</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2009&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2009&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2010</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2010&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2010&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2011</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2011&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2011&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2012</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2012&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2012&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2013</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2013&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2013&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
         <link>
           <year type="integer">2014</year>
           <interval type="integer">60</interval>
-          <link>http://developer.nrel.gov/api/solar/suny_india_download.csv?names=2014&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
+          <link>https://developer.nrel.gov/api/solar/suny_india_download.csv?names=2014&amp;wkt=POINT%2891.287+23.832%29&amp;interval=60&amp;api_key=yourapikey&amp;email=youremail</link>
         </link>
       </links>
     </output>

--- a/source/docs/solar/nsrdb/philippines-download.html.md.erb
+++ b/source/docs/solar/nsrdb/philippines-download.html.md.erb
@@ -260,7 +260,7 @@ Year,Month,Day,Hour,Minute,Temperature,Wind Speed
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "wkt=POINT (121.083336 17.05)&attributes=air_temperature,wind_speed&names=2017&utc=false&leap_day=true&interval=60&full_name=Valued%2BUser&email=valued.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic"
 

--- a/source/docs/solar/nsrdb/psm3-2-2-download.html.md.erb
+++ b/source/docs/solar/nsrdb/psm3-2-2-download.html.md.erb
@@ -276,7 +276,7 @@ Year,Month,Day,Hour,Minute,DHI,DNI,GHI,Clearsky DHI,Clearsky DNI,Clearsky GHI,Cl
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=2021&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed%2Cair_temperature&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 

--- a/source/docs/solar/nsrdb/psm3-2-2-tmy-download.html.md.erb
+++ b/source/docs/solar/nsrdb/psm3-2-2-tmy-download.html.md.erb
@@ -245,7 +245,7 @@ sd
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "wkt=POINT(-99.49218%2043.83452)&attributes=dhi%2Cdni%2Cghi%2Cdew_point%2Cair_temperature%2Csurface_pressure%2Cwind_direction%2Cwind_speed%2Csurface_albedo%2C%2C%2C&names=tmy-2017%2Ctdy-2017%2Ctgy-2017&full_name=Louis%20Bourbon&email=user@company.com&affiliation=NREL&mailing_list=false&reason=test&utc=true"
 

--- a/source/docs/solar/nsrdb/psm3-5min-download.html.md.erb
+++ b/source/docs/solar/nsrdb/psm3-5min-download.html.md.erb
@@ -265,7 +265,7 @@ Direct streaming of CSV data is supported for single location, single year only.
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=2018&leap_day=false&interval=15&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed%2Cair_temperature&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 

--- a/source/docs/solar/nsrdb/psm3-download.html.md.erb
+++ b/source/docs/solar/nsrdb/psm3-download.html.md.erb
@@ -285,7 +285,7 @@ Year,Month,Day,Hour,Minute,DHI,DNI,GHI,Clearsky DHI,Clearsky DNI,Clearsky GHI,Cl
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=2012&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed%2Cair_temperature&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 

--- a/source/docs/solar/nsrdb/psm3-tmy-download.html.md.erb
+++ b/source/docs/solar/nsrdb/psm3-tmy-download.html.md.erb
@@ -246,7 +246,7 @@ sd
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "wkt=POINT(-99.49218%2043.83452)&attributes=dhi%2Cdni%2Cghi%2Cdew_point%2Cair_temperature%2Csurface_pressure%2Cwind_direction%2Cwind_speed%2Csurface_albedo%2C%2C%2C&names=tmy-2017%2Ctdy-2017%2Ctgy-2017&full_name=Louis%20Bourbon&email=user@company.com&affiliation=NREL&mailing_list=false&reason=test&utc=true"
 

--- a/source/docs/solar/nsrdb/puerto-rico-download.html.md.erb
+++ b/source/docs/solar/nsrdb/puerto-rico-download.html.md.erb
@@ -254,7 +254,7 @@ Year,Month,Day,Hour,Minute,Air Temerature,Clearsky DHI,Clearsky DNI,Clearsky GHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=2012&leap_day=false&interval=60&utc=false&full_name=Valued%2BUser&email=valued.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed%2Cair_temperature&wkt=MULTIPOINT(-66.1057%2018.4655%2C-66.2057%2018.3655%2C-66.1157%2018.4655)"
 

--- a/source/docs/solar/nsrdb/spectral-india-tmy-download.html.md.erb
+++ b/source/docs/solar/nsrdb/spectral-india-tmy-download.html.md.erb
@@ -535,7 +535,7 @@ Year,Month,Day,Hour,Minute,Precip water (cm),hr mean ambient tmp,Wind speed (M/s
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=2012&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed_10m_nwp%2Csurface_air_temperature_nwp&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 

--- a/source/docs/solar/nsrdb/suny-india-data-download.html.md.erb
+++ b/source/docs/solar/nsrdb/suny-india-data-download.html.md.erb
@@ -284,7 +284,7 @@ Year,Month,Day,Hour,Minute,DHI,DNI,GHI,Clearsky DHI,Clearsky DNI,Clearsky GHI,De
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=2012&leap_day=false&interval=60&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed_10m_nwp%2Csurface_air_temperature_nwp&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 

--- a/source/docs/solar/nsrdb/suny-india-tmy-data-download.html.md.erb
+++ b/source/docs/solar/nsrdb/suny-india-tmy-data-download.html.md.erb
@@ -269,7 +269,7 @@ Year,Month,Day,Hour,Minute,DHI,DNI,GHI
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "names=tmy&leap_day=false&utc=false&full_name=Honored%2BUser&email=honored.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic&attributes=dhi%2Cdni%2Cwind_speed_10m_nwp%2Csurface_air_temperature_nwp&wkt=MULTIPOINT(-106.22%2032.9741%2C-106.18%2032.9741%2C-106.1%2032.9741)"
 

--- a/source/docs/solar/nsrdb/vietnam-download.html.md.erb
+++ b/source/docs/solar/nsrdb/vietnam-download.html.md.erb
@@ -260,7 +260,7 @@ Year,Month,Day,Hour,Minute,Temperature,Wind Speed
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "wkt=POINT (100 24)&attributes=air_temperature,wind_speed&names=2016&utc=false&leap_day=true&interval=60&full_name=Valued%2BUser&email=valued.user%40gmail.com&affiliation=NREL&mailing_list=true&reason=Academic"
 

--- a/source/docs/wave/guide.html.md.erb
+++ b/source/docs/wave/guide.html.md.erb
@@ -56,5 +56,5 @@ print(response.text)
 And a CURL example of the same
 
 ```shell
-curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Cache-Control: no-cache" -d 'utc=true&leap_day=true&interval=180&email=user@company.com&wkt=POINT(-164 15)&names=2010' "http://developer.nrel.gov/api/wave/v2/wave/hawaii-hindcast-download.json?api_key=yourapikeygoeshere"
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Cache-Control: no-cache" -d 'utc=true&leap_day=true&interval=180&email=user@company.com&wkt=POINT(-164 15)&names=2010' "https://developer.nrel.gov/api/wave/v2/wave/hawaii-hindcast-download.json?api_key=yourapikeygoeshere"
 ```

--- a/source/docs/wave/hindcast/alaska.html.md.erb
+++ b/source/docs/wave/hindcast/alaska.html.md.erb
@@ -258,7 +258,7 @@ Year,Month,Day,Hour,Minute,Directionality Coefficient,Energy Period,Maximum Ener
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "full_name=Sample+User&email=user@company.com&affiliation=Test+Organization&reason=Example&mailing_list=true&wkt=POINT (-160.491356 54.040203)&names=2010&utc=true&leap_day=true"
 

--- a/source/docs/wave/hindcast/hawaii.html.md.erb
+++ b/source/docs/wave/hindcast/hawaii.html.md.erb
@@ -259,7 +259,7 @@ Year,Month,Day,Hour,Minute,Directionality Coefficient,Energy Period,Maximum Ener
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "full_name=Sample+User&email=user@company.com&affiliation=Test+Organization&reason=Example&mailing_list=true&wkt=POINT (-164 15)&names=2010&utc=true&leap_day=true"
 

--- a/source/docs/wave/hindcast/us-atlantic.html.md.erb
+++ b/source/docs/wave/hindcast/us-atlantic.html.md.erb
@@ -260,7 +260,7 @@ Year,Month,Day,Hour,Minute,Directionality Coefficient,Energy Period,Maximum Ener
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "full_name=Sample+User&email=user@company.com&affiliation=Test+Organization&reason=Example&mailing_list=true&wkt=POINT (-80.643  24.382)&names=2010&utc=true&leap_day=true"
 

--- a/source/docs/wave/hindcast/us-west-coast.html.md.erb
+++ b/source/docs/wave/hindcast/us-west-coast.html.md.erb
@@ -259,7 +259,7 @@ Year,Month,Day,Hour,Minute,Directionality Coefficient,Energy Period,Maximum Ener
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "full_name=Sample+User&email=user@company.com&affiliation=Test+Organization&reason=Example&mailing_list=true&wkt=POINT (-124.2 46.2)&names=2010&utc=true&leap_day=true"
 

--- a/source/docs/wave/virtual-buoy/us-atlantic.html.md.erb
+++ b/source/docs/wave/virtual-buoy/us-atlantic.html.md.erb
@@ -259,7 +259,7 @@ Year,Month,Day,Hour,Minute,Energy Period,Maximum Energy Direction,Mean Wave Dire
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "full_name=Sample+User&email=user@company.com&affiliation=Test+Organization&reason=Example&mailing_list=true&wkt=POINT (-72.617 34.645)&names=2010&utc=true&leap_day=true"
 

--- a/source/docs/wave/virtual-buoy/us-west-coast.html.md.erb
+++ b/source/docs/wave/virtual-buoy/us-west-coast.html.md.erb
@@ -259,7 +259,7 @@ Year,Month,Day,Hour,Minute,Energy Period,Maximum Energy Direction,Mean Wave Dire
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "full_name=Sample+User&email=user@company.com&affiliation=Test+Organization&reason=Example&mailing_list=true&wkt=POINT (-124.728 48.494)&names=2010&utc=true&leap_day=true"
 

--- a/source/docs/wind/wind-toolkit/guide.html.md.erb
+++ b/source/docs/wind/wind-toolkit/guide.html.md.erb
@@ -38,7 +38,7 @@ In cases where a very large WKT value is required, e.g. downloading the maximum 
 ```python
 import requests
 
-url = "http://developer.nrel.gov/api/wind/offshore-nw-pacific-download.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov/api/wind/offshore-nw-pacific-download.json?api_key=yourapikeygoeshere"
 
 payload = "attributes=winddirection_180m&names=2017&utc=false&leap_day=true&email=user@company.com&wkt=POLYGON((-130.756145509839060 48.75520578942107,-130.75571635639668 48.75520578942107,-130.75571635639668 48.75485477666326,-130.75614550983906 48.75485477666326,-130.75614550983906 48.75520578942107))"
 
@@ -55,7 +55,7 @@ print(response.text)
 And a CURL example of the same
 
 ```shell
-curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Cache-Control: no-cache" -d 'attributes=winddirection_180m&names=2017&utc=false&leap_day=true&email=user@company.com&wkt=POLYGON((-130.756145509839060 48.75520578942107,-130.75571635639668 48.75520578942107,-130.75571635639668 48.75485477666326,-130.75614550983906 48.75485477666326,-130.75614550983906 48.75520578942107))' "http://developer.nrel.gov/api/wind/offshore-nw-pacific-download.json?api_key=yourapikeygoeshere"
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Cache-Control: no-cache" -d 'attributes=winddirection_180m&names=2017&utc=false&leap_day=true&email=user@company.com&wkt=POLYGON((-130.756145509839060 48.75520578942107,-130.75571635639668 48.75520578942107,-130.75571635639668 48.75485477666326,-130.75614550983906 48.75485477666326,-130.75614550983906 48.75520578942107))' "https://developer.nrel.gov/api/wind/offshore-nw-pacific-download.json?api_key=yourapikeygoeshere"
 ```
 
 ## Contact

--- a/source/docs/wind/wind-toolkit/index.html.md.erb
+++ b/source/docs/wind/wind-toolkit/index.html.md.erb
@@ -7,7 +7,7 @@ summary: Freely available downloads of Wind Integration National Dataset Toolkit
 # <%= current_page.data.title %>
 <%= current_page.data.summary %>
 
-The Wind Integration National Dataset (WIND) Toolkit is an update and expansion of the Eastern Integration Data Set and Western Wind Integration Data Set. It supports the next generation of wind integration studies. The WIND Toolkit includes meteorological conditions and turbine power for more than 126,000 sites in the continental United States for the years 2007—2013. Read more at [http://www.nrel.gov/grid/wind-toolkit.html](http://www.nrel.gov/grid/wind-toolkit.html)
+The Wind Integration National Dataset (WIND) Toolkit is an update and expansion of the Eastern Integration Data Set and Western Wind Integration Data Set. It supports the next generation of wind integration studies. The WIND Toolkit includes meteorological conditions and turbine power for more than 126,000 sites in the continental United States for the years 2007—2013. Read more at [https://www.nrel.gov/grid/wind-toolkit.html](https://www.nrel.gov/grid/wind-toolkit.html)
 
 
 <%= partial("layouts/child_links") %>

--- a/source/docs/wind/wind-toolkit/sup3rwind-ukraine-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/sup3rwind-ukraine-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-alaska-v1-0-0-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-alaska-v1-0-0-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-bangladesh-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-bangladesh-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-canada-5min-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-canada-5min-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-conus-5min-v2-0-0-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-conus-5min-v2-0-0-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-kazakhstan-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-kazakhstan-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-led-alaska-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-led-alaska-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-led-climate-v1-0-0-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-led-climate-v1-0-0-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-led-conus-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-led-conus-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-maine-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-maine-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-mexico-5min-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-mexico-5min-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-now23-california-v1-0-0-5min-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-now23-california-v1-0-0-5min-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-pr100-5min-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-pr100-5min-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-seasiawind-v3-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-seasiawind-v3-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 

--- a/source/docs/wind/wind-toolkit/wtk-south-atlantic-yearly-5min-v1-0-0-download.html.md.erb
+++ b/source/docs/wind/wind-toolkit/wtk-south-atlantic-yearly-5min-v1-0-0-download.html.md.erb
@@ -261,7 +261,7 @@ Year,Month,Day,Hour,Minute,wind direction at 180m (deg)
 ```python
 import requests
 
-url = "http://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
+url = "https://developer.nrel.gov<%= current_page.data.url %>.json?api_key=yourapikeygoeshere"
 
 payload = "api_key={{API_KEY}}&attributes=winddirection_180m&names=2017&utc=true&leap_day=true&interval=60&email=user@company.com&wkt=POINT(-179.99 -15.94)"
 


### PR DESCRIPTION
This covers only the NSRDB APIs, the WIND Toolkit APIs, and the Wave data APIs. The `http` version is not only bad form, but actually broke the examples using POST requests.