### PR TITLE
Add GitHub Action triggers for manual and nightly builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "8 5 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
- Add manual builds for rebuilding the static site more easily as needed.
- Add nightly builds to refresh the site nightly, since some of the documentation content is pulled via API and needs to be periodically refreshed. These nightly runs may help ensure the site stays in sync even if a manual run is forgotten.