### PR TITLE
removing address param from docs

### DIFF
--- a/source/docs/electricity/census-rate-v3.html.md.erb
+++ b/source/docs/electricity/census-rate-v3.html.md.erb
@@ -74,24 +74,8 @@ url: GET /api/census_rate/v3
       <td class="doc-parameter-description">Identifiying number provided by requester.</td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">address</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-        <div class="doc-parameter-value-field"></div>
-      </td>
-      <td class="doc-parameter-description">
-        <p>The address to use. Required if lat/lon not provided.</p>
-      </td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">lat</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -103,11 +87,11 @@ url: GET /api/census_rate/v3
           <strong>Range:</strong> <i>-90 to 90</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The latitude for the location to use. Required if address not given.</td>
+      <td class="doc-parameter-description">The latitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">lon</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -119,7 +103,7 @@ url: GET /api/census_rate/v3
           <strong>Range:</strong> <i>-180 to 180</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The longitude for the location to use. Required if address not given.</td>
+      <td class="doc-parameter-description">The longitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">region</th>
@@ -235,16 +219,6 @@ The response is composed of service-related informational fields and the results
       <th class="doc-parameter-name" scope="row">industrial</th>
       <td class="doc-parameter-value"><strong>Type:</strong> decimal</td>
       <td class="doc-parameter-description">The industrial electricity rate.</td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">partial_match</th>
-      <td class="doc-parameter-value"><strong>Type:</strong> boolean</td>
-      <td class="doc-parameter-description">A value of true indicates that the geocoder was not able to find an exact match on the original address. (only returned for address-based requests)</td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">geocoded_address</th>
-      <td class="doc-parameter-value"><strong>Type:</strong> string</td>
-      <td class="doc-parameter-description">The actual (possibly corrected) address used by the geocoder to determine lat/lon. (only returned for address-based requests)</td>
     </tr>
   </tbody>
 </table>

--- a/source/docs/electricity/utility-rates-v3.html.md.erb
+++ b/source/docs/electricity/utility-rates-v3.html.md.erb
@@ -66,24 +66,8 @@ Version 3 is the current version of the utility rates API. Previous versions hav
       </td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">address</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-        <div class="doc-parameter-value-field"></div>
-      </td>
-      <td class="doc-parameter-description">
-        <p>The address to use. Required if lat/lon not provided.</p>
-      </td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">lat</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -95,11 +79,11 @@ Version 3 is the current version of the utility rates API. Previous versions hav
           <strong>Range:</strong> <i>-90 to 90</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The latitude for the location to use. Required if address not given.</td>
+      <td class="doc-parameter-description">The latitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">lon</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -111,7 +95,7 @@ Version 3 is the current version of the utility rates API. Previous versions hav
           <strong>Range:</strong> <i>-180 to 180</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The longitude for the location to use. Required if address not given.</td>
+      <td class="doc-parameter-description">The longitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">radius</th>

--- a/source/docs/solar/data-query/v1.html.md.erb
+++ b/source/docs/solar/data-query/v1.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Solar Dataset Query V1
-summary: Returns information about data available for a given location for the solar resource database used by the <a href="/docs/solar/pvwatts/v6/">PVWatts v6 API</a>. 
+summary: Returns information about data available for a given location for the solar resource database used by the <a href="/docs/solar/pvwatts/v6/">PVWatts v6 API</a>.
 url: GET /api/solar/data_query/v1
 alias: docs/solar/data-query-v1/
 
@@ -61,21 +61,8 @@ alias: docs/solar/data-query-v1/
       </td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">address</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-      </td>
-      <td class="doc-parameter-description">The address to use. Required if lat/lon not specified.</td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">lat</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -90,11 +77,11 @@ alias: docs/solar/data-query-v1/
           <strong>Max:</strong> <i>90</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The latitude for the location to use. Required if address not specified.</td>
+      <td class="doc-parameter-description">The latitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">lon</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -109,7 +96,7 @@ alias: docs/solar/data-query-v1/
           <strong>Max:</strong> <i>180</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The longitude for the location to use. Required if address not specified.</td>
+      <td class="doc-parameter-description">The longitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">radius</th>

--- a/source/docs/solar/data-query/v2.html.md.erb
+++ b/source/docs/solar/data-query/v2.html.md.erb
@@ -60,21 +60,8 @@ url: GET /api/solar/data_query/v2
       </td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">address</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-      </td>
-      <td class="doc-parameter-description">The address to use. Required if lat/lon not specified.</td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">lat</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -89,11 +76,11 @@ url: GET /api/solar/data_query/v2
           <strong>Max:</strong> <i>90</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The latitude for the location to use. Required if address not specified.</td>
+      <td class="doc-parameter-description">The latitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">lon</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -108,7 +95,7 @@ url: GET /api/solar/data_query/v2
           <strong>Max:</strong> <i>180</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The longitude for the location to use. Required if address not specified.</td>
+      <td class="doc-parameter-description">The longitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">radius</th>
@@ -309,7 +296,8 @@ The output fields contain the following information regarding climate data files
   "metadata": {},
   "inputs": {
     "api_key": "DEMO_KEY",
-    "address": "boulder, co",
+    "lat": "40",
+    "lon": "-105",
     "radius": "0"
   },
   "outputs": {
@@ -377,7 +365,8 @@ The output fields contain the following information regarding climate data files
   </metadata>
   <inputs>
     <api-key>DEMO_KEY</api-key>
-    <address>boulder, co</address>
+    <lat>40</lat>
+    <lon>-105</lon>
     <radius>0</radius>
   </inputs>
   <outputs>

--- a/source/docs/solar/pvwatts/v6.html.md.erb
+++ b/source/docs/solar/pvwatts/v6.html.md.erb
@@ -222,23 +222,8 @@ The algorithms used to calculate energy output are the same as in Version 5. For
       <td class="doc-parameter-description">Azimuth angle (degrees).</td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">address</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-      </td>
-      <td class="doc-parameter-description">
-        <p>The address to use. Required if lat/lon or file_id not specified.</p>
-      </td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">lat</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -251,12 +236,12 @@ The algorithms used to calculate energy output are the same as in Version 5. For
         </div>
       </td>
       <td class="doc-parameter-description">
-        <p>The latitude for the location to use. Required if address or file_id not specified.</p>
+        <p>The latitude for the location to use. Required if file_id not specified.</p>
       </td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">lon</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -269,7 +254,7 @@ The algorithms used to calculate energy output are the same as in Version 5. For
         </div>
       </td>
       <td class="doc-parameter-description">
-        <p>The longitude for the location to use. Required if address or file_id not specified.</p>
+        <p>The longitude for the location to use. Required if file_id not specified.</p>
       </td>
     </tr>
     <tr>
@@ -284,7 +269,7 @@ The algorithms used to calculate energy output are the same as in Version 5. For
         </div>
       </td>
       <td class="doc-parameter-description">
-        Reference to a specific climate data file to use. Must be a valid <code>id</code> returned by the <a href="/docs/solar/data-query/v1/">Solar Dataset Query V1 API</a>. Required if lat/lon or address not specified.
+        Reference to a specific climate data file to use. Must be a valid <code>id</code> returned by the <a href="/docs/solar/data-query/v1/">Solar Dataset Query V1 API</a>. Required if lat/lon not specified.
       </td>
     </tr>
     <tr>

--- a/source/docs/solar/pvwatts/v8.html.md.erb
+++ b/source/docs/solar/pvwatts/v8.html.md.erb
@@ -223,21 +223,6 @@ There is a forthcoming report containing a technical description of the model.
       <td class="doc-parameter-description">Azimuth angle (degrees).</td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">address</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-      </td>
-      <td class="doc-parameter-description">
-        <p>The address to use. Required if lat/lon or file_id not specified.</p>
-      </td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">lat</th>
       <td class="doc-parameter-required">Depends</td>
       <td class="doc-parameter-value">
@@ -252,7 +237,7 @@ There is a forthcoming report containing a technical description of the model.
         </div>
       </td>
       <td class="doc-parameter-description">
-        <p>The latitude for the location to use. Required if address or file_id not specified.</p>
+        <p>The latitude for the location to use. Required if file_id not specified.</p>
       </td>
     </tr>
     <tr>
@@ -270,7 +255,7 @@ There is a forthcoming report containing a technical description of the model.
         </div>
       </td>
       <td class="doc-parameter-description">
-        <p>The longitude for the location to use. Required if address or file_id not specified.</p>
+        <p>The longitude for the location to use. Required if file_id not specified.</p>
       </td>
     </tr>
     <tr>
@@ -285,7 +270,7 @@ There is a forthcoming report containing a technical description of the model.
         </div>
       </td>
       <td class="doc-parameter-description">
-        Reference to a specific climate data file to use. Must be a valid <code>id</code> returned by the <a href="/docs/solar/data-query/v2/">Solar Dataset Query V2 API</a>. Required if lat/lon or address not specified.
+        Reference to a specific climate data file to use. Must be a valid <code>id</code> returned by the <a href="/docs/solar/data-query/v2/">Solar Dataset Query V2 API</a>. Required if lat/lon not specified.
       </td>
     </tr>
     <tr>
@@ -732,7 +717,7 @@ The response is composed of service-related informational fields and the results
 
 ### JSON Output Format
 
-<pre>GET <a href="/api/pvwatts/v8.json?api_key=DEMO_KEY&azimuth=180&system_capacity=4&losses=14&array_type=1&module_type=0&gcr=0.4&dc_ac_ratio=1.2&inv_eff=96.0&radius=0&dataset=nsrdb&tilt=10&address=boulder, co&soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&albedo=0.3&bifaciality=0.7">/api/pvwatts/v8.json?api_key=DEMO_KEY&amp;azimuth=180&amp;system_capacity=4&amp;losses=14&amp;array_type=1&amp;module_type=0&amp;gcr=0.4&amp;dc_ac_ratio=1.2&amp;inv_eff=96.0&amp;radius=0&amp;dataset=nsrdb&amp;tilt=10&amp;address=boulder, co&amp;soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&amp;albedo=0.3&amp;bifaciality=0.7</a></pre>
+<pre>GET <a href="/api/pvwatts/v8.json?api_key=DEMO_KEY&azimuth=180&system_capacity=4&losses=14&array_type=1&module_type=0&gcr=0.4&dc_ac_ratio=1.2&inv_eff=96.0&radius=0&dataset=nsrdb&tilt=10&lat=40&lon=-105&soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&albedo=0.3&bifaciality=0.7">/api/pvwatts/v8.json?api_key=DEMO_KEY&amp;azimuth=180&amp;system_capacity=4&amp;losses=14&amp;array_type=1&amp;module_type=0&amp;gcr=0.4&amp;dc_ac_ratio=1.2&amp;inv_eff=96.0&amp;radius=0&amp;dataset=nsrdb&amp;tilt=10&amp;lat=40&amp;lon=-105&amp;soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&amp;albedo=0.3&amp;bifaciality=0.7</a></pre>
 
 ```json
 {
@@ -749,7 +734,8 @@ The response is composed of service-related informational fields and the results
     "radius": "0",
     "dataset": "nsrdb",
     "tilt": "10",
-    "address": "boulder, co",
+    "lat": "40",
+    "lon": "-105",
     "soiling": [
       12.0,
       4.0,
@@ -852,7 +838,7 @@ The response is composed of service-related informational fields and the results
 
 ### XML Output Format
 
-<pre>GET <a href="/api/pvwatts/v8.xml?api_key=DEMO_KEY&azimuth=180&system_capacity=4&losses=14&array_type=1&module_type=0&gcr=0.4&dc_ac_ratio=1.2&inv_eff=96.0&radius=0&dataset=nsrdb&tilt=10&address=boulder, co&soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&albedo=0.3&bifaciality=0.7">/api/pvwatts/v8.xml?api_key=DEMO_KEY&amp;azimuth=180&amp;system_capacity=4&amp;losses=14&amp;array_type=1&amp;module_type=0&amp;gcr=0.4&amp;dc_ac_ratio=1.2&amp;inv_eff=96.0&amp;radius=0&amp;dataset=nsrdb&amp;tilt=10&amp;address=boulder, co&amp;soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&amp;albedo=0.3&amp;bifaciality=0.7</a></pre>
+<pre>GET <a href="/api/pvwatts/v8.xml?api_key=DEMO_KEY&azimuth=180&system_capacity=4&losses=14&array_type=1&module_type=0&gcr=0.4&dc_ac_ratio=1.2&inv_eff=96.0&radius=0&dataset=nsrdb&tilt=10&lat=40&lon=-105&soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&albedo=0.3&bifaciality=0.7">/api/pvwatts/v8.xml?api_key=DEMO_KEY&amp;azimuth=180&amp;system_capacity=4&amp;losses=14&amp;array_type=1&amp;module_type=0&amp;gcr=0.4&amp;dc_ac_ratio=1.2&amp;inv_eff=96.0&amp;radius=0&amp;dataset=nsrdb&amp;tilt=10&amp;lat=40&amp;lon=-105&amp;soiling=12|4|45|23|9|99|67|12.54|54|9|0|7.6&amp;albedo=0.3&amp;bifaciality=0.7</a></pre>
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -870,7 +856,8 @@ The response is composed of service-related informational fields and the results
     <radius>0</radius>
     <dataset>nsrdb</dataset>
     <tilt>10</tilt>
-    <address>boulder, co</address>
+    <lat>40</lat>,
+    <lon>-105</lon>,
     <soiling type="array">
       <soiling type="float">12.0</soiling>
       <soiling type="float">4.0</soiling>

--- a/source/docs/solar/solar-resource-v1.html.md.erb
+++ b/source/docs/solar/solar-resource-v1.html.md.erb
@@ -62,24 +62,8 @@ url: GET /api/solar/solar_resource/v1
       </td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">address</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-        <div class="doc-parameter-value-field"></div>
-      </td>
-      <td class="doc-parameter-description">
-        <p>The address to use. Required if lat/lon not specified.</p>
-      </td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">lat</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -91,11 +75,11 @@ url: GET /api/solar/solar_resource/v1
           <strong>Range:</strong> <i>-90 to 90</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The latitude for the location to use. Required if address not specified.</td>
+      <td class="doc-parameter-description">The latitude for the location to use.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">lon</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -107,7 +91,7 @@ url: GET /api/solar/solar_resource/v1
           <strong>Range:</strong> <i>-180 to 180</i>
         </div>
       </td>
-      <td class="doc-parameter-description">The longitude for the location to use. Required if address not specified.</td>
+      <td class="doc-parameter-description">The longitude for the location to use.</td>
     </tr>
   </tbody>
 </table>

--- a/source/docs/transportation/alt-fuel-stations-v1/nearby-route.html.md.erb
+++ b/source/docs/transportation/alt-fuel-stations-v1/nearby-route.html.md.erb
@@ -167,23 +167,6 @@ The response is composed of the fuel stations matching the requested query. For 
       </td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">latitude</th>
-      <td class="doc-parameter-value"><strong>Type:</strong> decimal</td>
-      <td class="doc-parameter-description">The latitude of the given location. This either matches the "latitude" parameter passed in, or is the geocoded latitude of the "location" parameter.</td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">longitude</th>
-      <td class="doc-parameter-value"><strong>Type:</strong> decimal</td>
-      <td class="doc-parameter-description">The longitude of the given location. This either matches the "longitude" parameter passed in, or is the geocoded longitude of the "location" parameter.</td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">precision</th>
-      <td class="doc-parameter-value"><strong>Type:</strong> record</td>
-      <td class="doc-parameter-description">
-        Details on the precision of the geocoded "location" parameter (if given). See <a href="#precision-record-fields">precision record fields</a> for response details.
-      </td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">fuel_stations</th>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
@@ -202,51 +185,6 @@ The response is composed of the fuel stations matching the requested query. For 
 The individual fuel station records are returned in order of ascending distance from the given location. Each station has the following attributes:
 
 <%= partial("docs/transportation/alt-fuel-stations-v1/record_fields", :locals => { :distance => true }) %>
-
-### Precision Record Fields
-
-<table border="0" cellpadding="0" cellspacing="0" class="doc-parameters">
-  <thead>
-    <tr>
-      <th class="doc-parameters-name" scope="col">Field</th>
-      <th class="doc-parameters-value" scope="col">Value</th>
-      <th class="doc-parameters-description" scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th class="doc-parameter-name" scope="row">name</th>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-      </td>
-      <td class="doc-parameter-description">A textual code for the accuracy of the geocoded location.</td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">value</th>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> integer
-        </div>
-      </td>
-      <td class="doc-parameter-description">
-        A numeric code for the accuracy of the geocoded location. These generally match the Google Geocoding API V2 <a href="https://developers.google.com/maps/documentation/geocoding/v2/#GeocodingAccuracy">accuracy values</a>.
-      </td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">types</th>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> array
-        </div>
-      </td>
-      <td class="doc-parameter-description">
-        An array of strings describing the type of location matched. These refer to the Google Geocoding API V3 <a href="https://developers.google.com/maps/documentation/geocoding/#Types">address component types</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 <%= partial("docs/transportation/alt-fuel-stations-v1/station_count_record_fields") %>
 

--- a/source/docs/transportation/alt-fuel-stations-v1/nearest.html.md.erb
+++ b/source/docs/transportation/alt-fuel-stations-v1/nearest.html.md.erb
@@ -31,31 +31,8 @@ The following query parameters may be passed in the request to control the outpu
   <tbody>
     <%= partial("docs/transportation/alt-fuel-stations-v1/request_params_common1") %>
     <tr>
-      <th class="doc-parameter-name" scope="row">location</th>
-      <td class="doc-parameter-required">Depends</td>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-        <div class="doc-parameter-value-field">
-          <strong>Default:</strong> None
-        </div>
-      </td>
-      <td class="doc-parameter-description">
-        <p>A free-form input describing the address of the location. This may include the address given in a variety of formats, such as:</p>
-        <ul>
-          <li>street, city, state, postal code</li>
-          <li>street, city, state</li>
-          <li>street, postal code</li>
-          <li>postal code</li>
-          <li>city, state</li>
-        </ul>
-        <p>(Either the <em>location</em> parameter or both the latitude and <em>longitude</em> parameters are required)</p>
-      </td>
-    </tr>
-    <tr>
       <th class="doc-parameter-name" scope="row">latitude</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -66,12 +43,11 @@ The following query parameters may be passed in the request to control the outpu
       </td>
       <td class="doc-parameter-description">
         <p>The latitude of the desired location.</p>
-        <p>(Either the <em>location</em> parameter or both the latitude and <em>longitude</em> parameters are required)</p>
       </td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">longitude</th>
-      <td class="doc-parameter-required">Depends</td>
+      <td class="doc-parameter-required">Yes</td>
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field">
           <strong>Type:</strong> decimal
@@ -82,7 +58,6 @@ The following query parameters may be passed in the request to control the outpu
       </td>
       <td class="doc-parameter-description">
         <p>The longitude of the desired location.</p>
-        <p>(Either the <em>location</em> parameter or both the latitude and <em>longitude</em> parameters are required)</p>
       </td>
     </tr>
     <tr>
@@ -168,19 +143,12 @@ The response is composed of the fuel stations matching the requested query. For 
     <tr>
       <th class="doc-parameter-name" scope="row">latitude</th>
       <td class="doc-parameter-value"><strong>Type:</strong> decimal</td>
-      <td class="doc-parameter-description">The latitude of the given location. This either matches the "latitude" parameter passed in, or is the geocoded latitude of the "location" parameter.</td>
+      <td class="doc-parameter-description">The latitude of the given input location.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">longitude</th>
       <td class="doc-parameter-value"><strong>Type:</strong> decimal</td>
-      <td class="doc-parameter-description">The longitude of the given location. This either matches the "longitude" parameter passed in, or is the geocoded longitude of the "location" parameter.</td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">precision</th>
-      <td class="doc-parameter-value"><strong>Type:</strong> record</td>
-      <td class="doc-parameter-description">
-        Details on the precision of the geocoded "location" parameter (if given). See <a href="#precision-record-fields">precision record fields</a> for response details.
-      </td>
+      <td class="doc-parameter-description">The longitude of the given input location.</td>
     </tr>
     <tr>
       <th class="doc-parameter-name" scope="row">fuel_stations</th>
@@ -202,71 +170,18 @@ The individual fuel station records are returned in order of ascending distance 
 
 <%= partial("docs/transportation/alt-fuel-stations-v1/record_fields", :locals => { :distance => true }) %>
 
-### Precision Record Fields
-
-<table border="0" cellpadding="0" cellspacing="0" class="doc-parameters">
-  <thead>
-    <tr>
-      <th class="doc-parameters-name" scope="col">Field</th>
-      <th class="doc-parameters-value" scope="col">Value</th>
-      <th class="doc-parameters-description" scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th class="doc-parameter-name" scope="row">name</th>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> string
-        </div>
-      </td>
-      <td class="doc-parameter-description">A textual code for the accuracy of the geocoded location.</td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">value</th>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> integer
-        </div>
-      </td>
-      <td class="doc-parameter-description">
-        A numeric code for the accuracy of the geocoded location. These generally match the Google Geocoding API V2 <a href="https://developers.google.com/maps/documentation/geocoding/v2/#GeocodingAccuracy">accuracy values</a>.
-      </td>
-    </tr>
-    <tr>
-      <th class="doc-parameter-name" scope="row">types</th>
-      <td class="doc-parameter-value">
-        <div class="doc-parameter-value-field">
-          <strong>Type:</strong> array
-        </div>
-      </td>
-      <td class="doc-parameter-description">
-        An array of strings describing the type of location matched. These refer to the Google Geocoding API V3 <a href="https://developers.google.com/maps/documentation/geocoding/#Types">address component types</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <%= partial("docs/transportation/alt-fuel-stations-v1/station_count_record_fields") %>
 
 ## Examples
 
 ### JSON Output Format
 
-<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.json?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.json?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1</a></pre>
+<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.json?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.json?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1</a></pre>
 
 ```json
 {
   "latitude": 39.743078,
   "longitude": -105.152278,
-  "location_country": "US",
-  "precision": {
-    "value": 9,
-    "name": "premise",
-    "types": [
-      "premise"
-    ]
-  },
   "station_locator_url": "https://afdc.energy.gov/stations/",
   "total_results": 82,
   "station_counts": {
@@ -388,7 +303,7 @@ The individual fuel station records are returned in order of ascending distance 
 
 ### GeoJSON Output Format
 
-<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.geojson?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.geojson?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1</a></pre>
+<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.geojson?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.geojson?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1</a></pre>
 
 ```json
 {
@@ -396,14 +311,6 @@ The individual fuel station records are returned in order of ascending distance 
   "metadata": {
     "latitude": 39.743078,
     "longitude": -105.152278,
-    "location_country": "US",
-    "precision": {
-      "value": 9,
-      "name": "premise",
-      "types": [
-        "premise"
-      ]
-    },
     "station_locator_url": "https://afdc.energy.gov/stations/",
     "total_results": 82,
     "station_counts": {
@@ -534,21 +441,13 @@ The individual fuel station records are returned in order of ascending distance 
 
 ### XML Output Format
 
-<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.xml?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.xml?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1</a></pre>
+<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.xml?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.xml?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1</a></pre>
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
   <latitude>39.743078</latitude>
   <longitude>-105.152278</longitude>
-  <location-country>US</location-country>
-  <precision>
-    <value type="integer">9</value>
-    <name>premise</name>
-    <types type="array">
-      <type>premise</type>
-    </types>
-  </precision>
   <station-locator-url>https://afdc.energy.gov/stations/</station-locator-url>
   <total-results>82</total-results>
   <station-counts>
@@ -670,7 +569,7 @@ The individual fuel station records are returned in order of ascending distance 
 
 ### KML Output Format
 
-<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.kml?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.kml?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1</a></pre>
+<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.kml?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.kml?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1</a></pre>
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -761,7 +660,7 @@ The individual fuel station records are returned in order of ascending distance 
 
 ### CSV Output Format
 
-<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.csv?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.csv?api_key=DEMO_KEY&amp;location=1617+Cole+Blvd+Golden+CO&amp;fuel_type=ELEC&amp;limit=1</a></pre>
+<pre>GET <a href="/api/alt-fuel-stations/v1/nearest.csv?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1">/api/alt-fuel-stations/v1/nearest.csv?api_key=DEMO_KEY&amp;latitude=39.743078&amp;longitude=-105.152278&amp;fuel_type=ELEC&amp;limit=1</a></pre>
 
 ```
 Fuel Type Code,Station Name,Street Address,Intersection Directions,City,State,ZIP,Plus4,Station Phone,Status Code,Expected Date,Groups With Access Code,Access Days Time,Cards Accepted,BD Blends,NG Fill Type Code,NG PSI,EV Level1 EVSE Num,EV Level2 EVSE Num,EV DC Fast Count,EV Other Info,EV Network,EV Network Web,Geocode Status,Latitude,Longitude,Date Last Confirmed,ID,Updated At,Owner Type Code,Federal Agency ID,Federal Agency Name,Open Date,Hydrogen Status Link,NG Vehicle Class,LPG Primary,E85 Blender Pump,EV Connector Types,Country,Intersection Directions (French),Access Days Time (French),BD Blends (French),Groups With Access Code (French),Hydrogen Is Retail,Access Code,Access Detail Code,Federal Agency Code,Facility Type,CNG Dispenser Num,CNG On-Site Renewable Source,CNG Total Compression Capacity,CNG Storage Capacity,LNG On-Site Renewable Source,E85 Other Ethanol Blends,EV Pricing,EV Pricing (French),LPG Nozzle Types,Hydrogen Pressures,Hydrogen Standards,CNG Fill Type Code,CNG PSI,CNG Vehicle Class,LNG Vehicle Class,EV On-Site Renewable Source,Restricted Access,RD Blends,RD Blends (French),RD Blended with Biodiesel,RD Maximum Biodiesel Level,Maximum Vehicle Class


### PR DESCRIPTION
Removing `address` param from various docs because we are removing support for it.