### PR TITLE
NPM package security updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.8",
-    "@eslint/js": "^9.25.1",
+    "@eslint/js": "^9.39.1",
     "@stoplight/spectral-cli": "^6.15.0",
     "autoprefixer": "^10.4.21",
-    "eslint": "^9.25.1",
+    "eslint": "^9.39.2",
     "gh-pages": "^6.3.0",
     "globals": "^16.0.0",
     "sass": "^1.87.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "domready": "^1.0.8",
     "escape-html": "^1.0.3",
     "form-serialize": "^0.7.2",
-    "swagger-ui": "^5.21.0"
+    "swagger-ui": "5.27.1"
   },
   "devDependencies": {
     "@eslint/compat": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "swagger-ui": "^5.21.0"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.2.8",
+    "@eslint/compat": "^1.4.1",
     "@eslint/js": "^9.39.1",
     "@stoplight/spectral-cli": "^6.15.0",
     "autoprefixer": "^10.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,10 +44,10 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.8
-        version: 1.2.8(eslint@9.25.1)
+        version: 1.2.8(eslint@9.39.2)
       '@eslint/js':
-        specifier: ^9.25.1
-        version: 9.25.1
+        specifier: ^9.39.1
+        version: 9.39.2
       '@stoplight/spectral-cli':
         specifier: ^6.15.0
         version: 6.15.0
@@ -55,8 +55,8 @@ importers:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
       eslint:
-        specifier: ^9.25.1
-        version: 9.25.1
+        specifier: ^9.39.2
+        version: 9.39.2
       gh-pages:
         specifier: ^6.3.0
         version: 6.3.0
@@ -224,8 +224,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.6.1':
-    resolution: {integrity: sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==}
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -243,32 +243,32 @@ packages:
       eslint:
         optional: true
 
-  '@eslint/config-array@0.20.0':
-    resolution: {integrity: sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==}
+  '@eslint/config-array@0.21.1':
+    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.2.1':
-    resolution: {integrity: sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.13.0':
-    resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.25.1':
-    resolution: {integrity: sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==}
+  '@eslint/js@9.39.2':
+    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/object-schema@2.1.6':
-    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.2.8':
-    resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@fontsource-variable/roboto@5.2.5':
@@ -806,8 +806,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.14.1:
-    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1148,20 +1148,20 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-scope@8.3.0:
-    resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-visitor-keys@4.2.0:
-    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.25.1:
-    resolution: {integrity: sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==}
+  eslint@9.39.2:
+    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -1170,8 +1170,8 @@ packages:
       jiti:
         optional: true
 
-  espree@10.3.0:
-    resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esquery@1.6.0:
@@ -2518,28 +2518,30 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.6.1(eslint@9.25.1)':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2)':
     dependencies:
-      eslint: 9.25.1
+      eslint: 9.39.2
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.2.8(eslint@9.25.1)':
+  '@eslint/compat@1.2.8(eslint@9.39.2)':
     optionalDependencies:
-      eslint: 9.25.1
+      eslint: 9.39.2
 
-  '@eslint/config-array@0.20.0':
+  '@eslint/config-array@0.21.1':
     dependencies:
-      '@eslint/object-schema': 2.1.6
+      '@eslint/object-schema': 2.1.7
       debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.2.1': {}
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
 
-  '@eslint/core@0.13.0':
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -2547,7 +2549,7 @@ snapshots:
     dependencies:
       ajv: 6.12.6
       debug: 4.4.0
-      espree: 10.3.0
+      espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
@@ -2557,13 +2559,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.25.1': {}
+  '@eslint/js@9.39.2': {}
 
-  '@eslint/object-schema@2.1.6': {}
+  '@eslint/object-schema@2.1.7': {}
 
-  '@eslint/plugin-kit@0.2.8':
+  '@eslint/plugin-kit@0.4.1':
     dependencies:
-      '@eslint/core': 0.13.0
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@fontsource-variable/roboto@5.2.5': {}
@@ -3434,11 +3436,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  acorn-jsx@5.3.2(acorn@8.14.1):
+  acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
 
-  acorn@8.14.1: {}
+  acorn@8.15.0: {}
 
   ajv-draft-04@1.0.0(ajv@8.17.1):
     optionalDependencies:
@@ -3844,38 +3846,37 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-scope@8.3.0:
+  eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.2.0: {}
+  eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.25.1:
+  eslint@9.39.2:
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.25.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2)
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.20.0
-      '@eslint/config-helpers': 0.2.1
-      '@eslint/core': 0.13.0
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.25.1
-      '@eslint/plugin-kit': 0.2.8
+      '@eslint/js': 9.39.2
+      '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.2
       '@types/estree': 1.0.7
-      '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.0
       escape-string-regexp: 4.0.0
-      eslint-scope: 8.3.0
-      eslint-visitor-keys: 4.2.0
-      espree: 10.3.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
       esquery: 1.6.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -3893,11 +3894,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  espree@10.3.0:
+  espree@10.4.0:
     dependencies:
-      acorn: 8.14.1
-      acorn-jsx: 5.3.2(acorn@8.14.1)
-      eslint-visitor-keys: 4.2.0
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
 
   esquery@1.6.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         version: 5.21.0
     devDependencies:
       '@eslint/compat':
-        specifier: ^1.2.8
-        version: 1.2.8(eslint@9.39.2)
+        specifier: ^1.4.1
+        version: 1.4.1(eslint@9.39.2)
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.2
@@ -234,11 +234,11 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/compat@1.2.8':
-    resolution: {integrity: sha512-LqCYHdWL/QqKIJuZ/ucMAv8d4luKGs4oCPgpt8mWztQAtPrHfXKQ/XAUc8ljCHAfJCn6SvkpTcGt5Tsh8saowA==}
+  '@eslint/compat@1.4.1':
+    resolution: {integrity: sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^9.10.0
+      eslint: ^8.40 || 9
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -2525,7 +2525,9 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.2.8(eslint@9.39.2)':
+  '@eslint/compat@1.4.1(eslint@9.39.2)':
+    dependencies:
+      '@eslint/core': 0.17.0
     optionalDependencies:
       eslint: 9.39.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2
       swagger-ui:
-        specifier: ^5.21.0
-        version: 5.21.0
+        specifier: 5.27.1
+        version: 5.27.1
     devDependencies:
       '@eslint/compat':
         specifier: ^1.4.1
@@ -78,12 +78,12 @@ packages:
   '@asyncapi/specs@6.8.1':
     resolution: {integrity: sha512-czHoAk3PeXTLR+X8IUaD+IpT+g+zUvkcgMDJVothBsan+oHN3jfcFcFUNdOPAAFoUCQN1hXF1dWuphWy05THlA==}
 
-  '@babel/runtime-corejs3@7.27.0':
-    resolution: {integrity: sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==}
+  '@babel/runtime-corejs3@7.28.4':
+    resolution: {integrity: sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.27.0':
-    resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -650,104 +650,117 @@ packages:
     resolution: {integrity: sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==}
     engines: {node: '>=10.8'}
 
-  '@swagger-api/apidom-ast@1.0.0-beta.31':
-    resolution: {integrity: sha512-Nadp6UA+eQ3bRmFqI6+xmDbEbRN0Q/J7XQhPspTla4ZAuk2e4XNyExYZHyZsh+GHQVVWqqtKRSkFeWNhOlzkjA==}
+  '@swagger-api/apidom-ast@1.0.2':
+    resolution: {integrity: sha512-R3lMQDVmSLAIInWRfyBXNuaEwn6crUzNfTJZ6/HXaYheIicnQBJ2BnPA2ETKLFau44Xo7ej5hElCFO7DKOT7vg==}
 
-  '@swagger-api/apidom-core@1.0.0-beta.31':
-    resolution: {integrity: sha512-MH3D+Ig039Ps1OG+nHm+Xo/6GsdU8MKxClHTPuNxBBPhHL4fvL3/0gmE5HsT2ydNIeXZZbb4GHmq2ZxvpzBzsA==}
+  '@swagger-api/apidom-core@1.0.2':
+    resolution: {integrity: sha512-nsZVfIVs48x9tbCqGiGxofR5ogrGfDIrUTYEcP3XHkWnfwKY7d7xWfjB7MHT4LtqrbbXzs+NGRvzrx7OLZt5/w==}
 
-  '@swagger-api/apidom-error@1.0.0-beta.31':
-    resolution: {integrity: sha512-N6wW3ie8fhbQCGceA2q7IjDcafZIBFpq0Bo6yOEsBMSe/Lu1/3lNi/mlqw4oUfUil6VMNX2BchCZnbJ5FeUyPQ==}
+  '@swagger-api/apidom-error@1.0.2':
+    resolution: {integrity: sha512-tGPdBugCpBj6p7S8jtpXkElzovwH/uR0HFcDEWyt4qK3U4v8ZZDcefqdpzFoC7ey1Akd4E+VyKsjJRBufBl7bA==}
 
-  '@swagger-api/apidom-json-pointer@1.0.0-beta.31':
-    resolution: {integrity: sha512-ndqp4696NVIuZAL6C/T+YZqDyrW9lJLHtzCoO5hkg5ytMO1Zv4ht3H1EWr7819ryDRLhiVlQ/kCnJO6gutYvlA==}
+  '@swagger-api/apidom-json-pointer@1.0.2':
+    resolution: {integrity: sha512-5jd8T5P3T5e6Tl6xXBEDch2RzNSOb7OLQ6/rmmMbQA5ie+bR3oBqTTDEW+Sn7uDTGCpsEg2yTRn3RHnre7gWcg==}
 
-  '@swagger-api/apidom-ns-api-design-systems@1.0.0-beta.31':
-    resolution: {integrity: sha512-e6+OL2tIjPBeUtai0HxeRdaHn6bE/AfSS0CGSUfJY/Op1mNDXHGHZTuuMHDj5+P6Ojx7W6RWEUwh2m505aCScA==}
+  '@swagger-api/apidom-ns-api-design-systems@1.0.2':
+    resolution: {integrity: sha512-FOLJBNzKXwEnYtudCXuYaEtv1a6NkrH1abC6j9g/qqtBKdGoAKyH4C2uUQyfqJkNdNyaJ4/rv1uyIowJ3gjkKw==}
 
-  '@swagger-api/apidom-ns-arazzo-1@1.0.0-beta.31':
-    resolution: {integrity: sha512-gqQAS4hu7odNjnBgkYOSRdhvAMlxG+xYg8tBDeHU+SUc8Md2DsWrWZ/aLpV7yLumDvWJi2CQEjQ9smqQ45A/zw==}
+  '@swagger-api/apidom-ns-arazzo-1@1.0.2':
+    resolution: {integrity: sha512-f5yH9CMhfb678c7l1bj7sr2zWDvpBOmOqI70Suq59FkPVVjEQsaHx9hnSZ/ZT7Oi9gbEFXU/pGpt25zgjSkn9w==}
 
-  '@swagger-api/apidom-ns-asyncapi-2@1.0.0-beta.31':
-    resolution: {integrity: sha512-kOvWhFEeJFDOpoYyemqjgxVlD+GasJlfoWS9VPDrOcxuhnd1UngrtSMSkSoUixyVhxyyoYQgsuqzAfdaf4phmg==}
+  '@swagger-api/apidom-ns-asyncapi-2@1.0.2':
+    resolution: {integrity: sha512-tJ6HK9RLISKJ/L/7K7Ai0AvediODzPFL4uqUyvggyoNZuLIoQMlTZp3wcdyu/VLyTo25r0TY57H3HysDbwbBHA==}
 
-  '@swagger-api/apidom-ns-json-schema-2019-09@1.0.0-beta.31':
-    resolution: {integrity: sha512-diRKrijUbHALRcu0BRZxM8OXi4VAcM3K1yxWMiwQN6xuQjb5IpXMDsTjcHr6WqeJb9JVZBIIsyA/5oaUK9ePKA==}
+  '@swagger-api/apidom-ns-asyncapi-3@1.0.2':
+    resolution: {integrity: sha512-ToR8gMe7s/MoZ5YZj2W05Y5o6ZY6zzUvFgedI2PqkBp7CP5X5dFVynF6yE8jC6G1J9qv3nUekS2CQdrfZM/ONA==}
 
-  '@swagger-api/apidom-ns-json-schema-2020-12@1.0.0-beta.31':
-    resolution: {integrity: sha512-ueOPpsB3u87zuX5T+BHC+1oJDxo0284/nAtMYs3DKS7KDHrRLG/8j2J/Xh6UZCD6Al3fkNSgVkcbDQ5XlcYT7w==}
+  '@swagger-api/apidom-ns-json-schema-2019-09@1.0.2':
+    resolution: {integrity: sha512-Zkc7eZFinqXqsZKHypMisFb/5+CfFIwn1/YYFF0RVpuV232q2ITjt5X+YJMvHLIaBbotrtuAoMSrN1YdN8ZHXQ==}
 
-  '@swagger-api/apidom-ns-json-schema-draft-4@1.0.0-beta.31':
-    resolution: {integrity: sha512-f6y/hWbbtGF5vk7tC2Pepy+FWM7Rhv3mKnT0bsHhodioDR7JHGYoVNYVi7od07bwn/WtyYs/0riPsPJ8HXR4+Q==}
+  '@swagger-api/apidom-ns-json-schema-2020-12@1.0.2':
+    resolution: {integrity: sha512-QJ7nuLGQ3Xof9pfAG4n+0fSkdUeHrV26fBPMo89oTI/+nN2/I9X+ZVgGjgaJ1GJTAM0aIz1PW+KmsontUF4OiA==}
 
-  '@swagger-api/apidom-ns-json-schema-draft-6@1.0.0-beta.31':
-    resolution: {integrity: sha512-tCJ1HdUG7snYR0yiF3VsAs7Cprg8XiEUV2piO5+8qY28KLBiojC0NK40F4/q+sSiFVEidhWIDG7k4E1aLEFo9g==}
+  '@swagger-api/apidom-ns-json-schema-draft-4@1.0.2':
+    resolution: {integrity: sha512-pkinTc04ho3XfiwA81/GJc4SrPBohm+pOfMs7BJl70jz39wx9DTVHkwYLKIgg2NDspDCdUppw9IgsvW0T6AkJA==}
 
-  '@swagger-api/apidom-ns-json-schema-draft-7@1.0.0-beta.31':
-    resolution: {integrity: sha512-GvLXWvcDLmxFB5CfJ52ql6Gja7unwi56Qrg9TR8pdFZ2bmc1ZvYes+yd++HCwwVQIBouYZyt5GNSVEbJTYTkxQ==}
+  '@swagger-api/apidom-ns-json-schema-draft-6@1.0.2':
+    resolution: {integrity: sha512-+pfyLvWotVnzeAD3YWuMMLzlr4UeXUkWC0Sc2lzqojXSV3a07xDI76dxZtAGY1nL5Ste/8UQv4n6e/oNX2i6XA==}
 
-  '@swagger-api/apidom-ns-openapi-2@1.0.0-beta.31':
-    resolution: {integrity: sha512-ItEShoLNenAzRA73bGItUGVWnLWVf2C/glkdoVLNn+ubhnv5F908YP8qtytO/nh9+pX2I1Q0C0uznhDM5RTlhw==}
+  '@swagger-api/apidom-ns-json-schema-draft-7@1.0.2':
+    resolution: {integrity: sha512-igaaNBHYf8Q+G3xdX/aUE036fJDCUdjqd6t7mqs7FEod0iwD/01rkBxJ/A3+uJ6ssMDvwlzhP/DKmF0dmfC8iw==}
 
-  '@swagger-api/apidom-ns-openapi-3-0@1.0.0-beta.31':
-    resolution: {integrity: sha512-MfjA/UKs7dvXULUMqu8HbqqJXM9az+CiNQVyQFOBYsaUsWFEfn0k+QejDvRfXZtZ6ZzRSyXSRASLoPXIFQrgcQ==}
+  '@swagger-api/apidom-ns-openapi-2@1.0.2':
+    resolution: {integrity: sha512-8UgafKSlkGejFeFD4bjjeaTrzjtfAHk32Zfetdek2ddVwL0vbwsrvtGjsAvwdKesYSoh1d/45reOdQ3QX5dshw==}
 
-  '@swagger-api/apidom-ns-openapi-3-1@1.0.0-beta.31':
-    resolution: {integrity: sha512-yhZkxuaSgyqdWn+VQSRngjxv9W2lyN6RJTHBoMcoIRkZdc2JbsPwzJxms1LgueAiL6f5IMlQa+3fG57GL7C51w==}
+  '@swagger-api/apidom-ns-openapi-3-0@1.0.2':
+    resolution: {integrity: sha512-Fl2RAGRDMVwt86yIlDf20A5rmuFvqj+gk+/4t7A2B0TucRNt9e1xUq394mmFC6wwpTj9LOuK7OTPqiWuqYOcCQ==}
 
-  '@swagger-api/apidom-parser-adapter-api-design-systems-json@1.0.0-beta.31':
-    resolution: {integrity: sha512-W9cwv+Xw6O6BCCgmbP1QuPEqQoUEN/kA0WtOrgdhGThWfSG5lXuBlBw7jkJ91x65UdMP+04NOTx64OgYxwaIQg==}
+  '@swagger-api/apidom-ns-openapi-3-1@1.0.2':
+    resolution: {integrity: sha512-nypY4b/MF7xma6B8GBCJXCbtYv+i8DnBL1AS3QgcD23TfAjeuFKOr1e7tBCx/xKKKX7XUra0HfnDeRBFCD1MWA==}
 
-  '@swagger-api/apidom-parser-adapter-api-design-systems-yaml@1.0.0-beta.31':
-    resolution: {integrity: sha512-nDD9zxB85Z7P8aQNu2lYUMvQeR064MwdntRcsqBJkuNEcGK8pNeW1nA3d4XfKEgkRl6Ct+NXclJjT9ipT7D4bQ==}
+  '@swagger-api/apidom-parser-adapter-api-design-systems-json@1.0.2':
+    resolution: {integrity: sha512-L5MmNHCIvNNAzxplpf/c6dCznjWEPW4zei+S2IbW/YScJDinA82AYa1v1t4vDRjN7wAADmM5BkgSbnV8A79oJA==}
 
-  '@swagger-api/apidom-parser-adapter-arazzo-json-1@1.0.0-beta.31':
-    resolution: {integrity: sha512-QvTWU2Q3raTdfOPrQS0JpGlde+HkgC+b2Y3fvV9ywJYbAhdCr1JEJhi/m8P0O/KD7WvyVdJWS0e1E5VhYx8qgg==}
+  '@swagger-api/apidom-parser-adapter-api-design-systems-yaml@1.0.2':
+    resolution: {integrity: sha512-VUgzJ+nGqe3JCZKNMT1D2QrPxLEj+t1IAg3UhjhoVXVOMZgnjZ63c0rd+LWKyXkuors+lj/aWPDQcsTo0/AsHQ==}
 
-  '@swagger-api/apidom-parser-adapter-arazzo-yaml-1@1.0.0-beta.31':
-    resolution: {integrity: sha512-g6Ckqw4tS6K2OmX22+ihTPKXKBVUGPPVrURl5V+XDiGSQ+a89lkC9eQKj63I7oyi7dAIXIvJ7BtiD4l91U1Izg==}
+  '@swagger-api/apidom-parser-adapter-arazzo-json-1@1.0.2':
+    resolution: {integrity: sha512-6uH9yTHh98i4m/9RMCxfiKAJTzFYyxLJBHfWCznaS/5u2Tfh5pzS08GXgXKNxvbyG5HzkPQQ9Y3BNpapZrxOxA==}
 
-  '@swagger-api/apidom-parser-adapter-asyncapi-json-2@1.0.0-beta.31':
-    resolution: {integrity: sha512-DGhSTCSNbzTr0oSXauzsIcOoLnr0YU0v/EZjGs+wfILH1NMrV8NqYYCYqlecLCWHGVdeIII/ByN2lqS4b92q9w==}
+  '@swagger-api/apidom-parser-adapter-arazzo-yaml-1@1.0.2':
+    resolution: {integrity: sha512-LYAPEERgFwvOIePTiu3q7Nf/7vBaUXGofs3a5/RsO90HZeeWd2DlBlKCqOXKQkC20yb2BGmAIam41exmp1UTiA==}
 
-  '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@1.0.0-beta.31':
-    resolution: {integrity: sha512-gF98gebFpMNbFkads2HPJAePK39K6sd1U3RTRn/dZ1pSoyk2GQBb4UuCnBMb06/RCI/qBWPcFfrnKWnzmcyZgw==}
+  '@swagger-api/apidom-parser-adapter-asyncapi-json-2@1.0.2':
+    resolution: {integrity: sha512-/AzWfO11QH6Yt6bwVHl/eBsxhUeYkiBPUVe8JRhZacADnetex4Rchq+UD7Z4h+1zpnpz6Nq6Gp/V+dc7tyCUaQ==}
 
-  '@swagger-api/apidom-parser-adapter-json@1.0.0-beta.31':
-    resolution: {integrity: sha512-mILKclnBjbjDR/hhDuHv0m6w1AE5xrvRk6Dcj2Y02wNXepnSxzlXwlfLx9gMXWic9m1wxB3CAxnkWHTGVWxUSg==}
+  '@swagger-api/apidom-parser-adapter-asyncapi-json-3@1.0.2':
+    resolution: {integrity: sha512-QG4I6Ui9ZfmW5rVn7fms3swTO+/WPGQqsxpLAamicgOANBx5ZWNmcF9/+rRhQx1N4m3mcb+tZvNN7Ks2RFkasw==}
 
-  '@swagger-api/apidom-parser-adapter-openapi-json-2@1.0.0-beta.31':
-    resolution: {integrity: sha512-jmkmmFHpVynAB08cknlPa0XuYdtbxYYPv1WrconxzD4ItAbBIhRDOg10wzk9LahquPj/iZjoqlY9qNS4i30u6w==}
+  '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@1.0.2':
+    resolution: {integrity: sha512-jCd0LYsrvZ/3iKOii61bV1fweaHvH0eL41LIILccZIJ1INXnr04a65bykLZKVNXkmEMGwRL/HKw2DFPfEiwTGA==}
 
-  '@swagger-api/apidom-parser-adapter-openapi-json-3-0@1.0.0-beta.31':
-    resolution: {integrity: sha512-cU46ICL4jmzLNhnL20xSmSAeYXfXM30HCO0qNy8/ezVH5EaflOVjbDGBKTpo6xkfMwpCbxjWF4eiVW4Z1zXTQA==}
+  '@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@1.0.2':
+    resolution: {integrity: sha512-qULlgtFbfNanXLV+fvz6I/NtEQGNyXcYk/QmeNq8Nio6o82y7raUEirhG1GqFeSop81fZNhwiYfKvnI/OBZ/Eg==}
 
-  '@swagger-api/apidom-parser-adapter-openapi-json-3-1@1.0.0-beta.31':
-    resolution: {integrity: sha512-VyEv4jSr0BKdICtW3M/aGwyHhNmcgnBrIcSXnWXDdNkEBg83UKwH/Y4UcI4T3TAyddq8Y6jtJvPJGD8DhddvwQ==}
+  '@swagger-api/apidom-parser-adapter-json@1.0.2':
+    resolution: {integrity: sha512-dBT/cchJJg5E/Ma9hkTSwYNqnVD1kst8NUElx2zAP/2y+T8gBqb/quUl60Hsnj/kVga0J1IKsfADy3fyGmaS6g==}
 
-  '@swagger-api/apidom-parser-adapter-openapi-yaml-2@1.0.0-beta.31':
-    resolution: {integrity: sha512-uh91S/Md6RYUSqL5sd72EASOCyZ6bK+lNkfZ2H/vIyED9X0kdmnzmoIR7uCce5iFBksrhXu1zY7Ra2/BFbp52A==}
+  '@swagger-api/apidom-parser-adapter-openapi-json-2@1.0.2':
+    resolution: {integrity: sha512-1eo6UEuM3SCA2ZJCy3+0irTHAVx0Z7JkLjRQITneZbNSk+NedfMoUHxC3gQ0doOccHrmZTtSloy2/Gk6to27Ww==}
 
-  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@1.0.0-beta.31':
-    resolution: {integrity: sha512-3mx5c5TucPSdRO62GiGngNaeBisqdj8vPf1tnmzphBKiJWXQPJJMU34/uuOK/PdI8zWGcaM5/18Y1NfQsRhQkw==}
+  '@swagger-api/apidom-parser-adapter-openapi-json-3-0@1.0.2':
+    resolution: {integrity: sha512-oU68kP3B7yuJ5tPC+uhbiJ1p4ZvpkEFyofxn7wdX3RAjwzlvu33lh5hitChNK0a2oPkOFQSUuaCj3AIGrqQMQA==}
 
-  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@1.0.0-beta.31':
-    resolution: {integrity: sha512-T4G/Ezyo74UGKvOoo1mO+TkEL1NFNf8UF7M//BU+6YybTyaIyfyAeYhxfN/THYxbDeXaGoTb0KA+48VNvKjGCA==}
+  '@swagger-api/apidom-parser-adapter-openapi-json-3-1@1.0.2':
+    resolution: {integrity: sha512-dEVi/iMIpf4CnkMCruSNrlIHTgczxwNYWC6bzRV3K/F0Dal3brgSKPvzdu7wjEkVia7BPslp2TSjRPCJ5/uSLw==}
 
-  '@swagger-api/apidom-parser-adapter-yaml-1-2@1.0.0-beta.31':
-    resolution: {integrity: sha512-AKZ4luO6dxDRq4N+4Nk70c+v9PmWTewaRHV9xmUNn1PhFOZOFwlWorFBRWc9+74ELCh9TaYyUcVmhlH4TuuCVQ==}
+  '@swagger-api/apidom-parser-adapter-openapi-yaml-2@1.0.2':
+    resolution: {integrity: sha512-aHrOCbMROgmjBwcJsgkBacwXJbAU/wPxvbTegFzvPy6dGtfGZLM91G7lYIN7r7FEf4OK4T7AKFrwEy9UO6sYTA==}
 
-  '@swagger-api/apidom-reference@1.0.0-beta.31':
-    resolution: {integrity: sha512-JfXLBY+jeZSq8PYCLxTqIiOj5cwVroUyYilakVRYIeJs95Zp5PXnSJ/vMcfK3w8dBmD9gcCBQbQ5nI2W1r0nXA==}
+  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@1.0.2':
+    resolution: {integrity: sha512-+xZhqGJmFNTdrsqBYeZm9PMNaqHj73EX6tv6nXhVELSNoRiWbpO+XzLQS12P2NSH9Cwx12qS/PgsskbIVX1drQ==}
+
+  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@1.0.2':
+    resolution: {integrity: sha512-I6f0vV0uFbV8bpBcmhzdb7u2b6IG3MChzNXYu6bd+OyBcJmLbaoOsPnpMYVDwsNxz50S23mmh/hZQSznq6OQ9Q==}
+
+  '@swagger-api/apidom-parser-adapter-yaml-1-2@1.0.2':
+    resolution: {integrity: sha512-zRHrlTI5Yv1+mxRbfDKaYLWBoJC8kqBtPl0LGvxrOtZA+6KKTIqJcwrAqvrmZFH0a5QaxIj1ldG6Ll0Oo0++TQ==}
+
+  '@swagger-api/apidom-reference@1.0.2':
+    resolution: {integrity: sha512-LuFp3BmkYccB6Eb/k1q9s6ojWG4tC66hq8kfVifmn21u4Hz2k517JdRfyXuLX4BJFZhPPZBXmLulhbPMp6O4Uw==}
 
   '@swaggerexpert/cookie@2.0.2':
     resolution: {integrity: sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==}
     engines: {node: '>=12.20.0'}
 
-  '@tree-sitter-grammars/tree-sitter-yaml@0.7.0':
-    resolution: {integrity: sha512-GOMIK3IaDvECD0eZEhAsLl03RMtM1E8StxuGMn6PpMKFg7jyQ+jSzxJZ4Jmc/tYitah9/AECt8o4tlRQ5yEZQg==}
+  '@swaggerexpert/json-pointer@2.10.2':
+    resolution: {integrity: sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==}
+    engines: {node: '>=12.20.0'}
+
+  '@tree-sitter-grammars/tree-sitter-yaml@0.7.1':
+    resolution: {integrity: sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==}
     peerDependencies:
-      tree-sitter: ^0.22.1
+      tree-sitter: ^0.22.4
     peerDependenciesMeta:
       tree-sitter:
         optional: true
@@ -846,8 +859,8 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  apg-lite@1.0.4:
-    resolution: {integrity: sha512-B32zCN3IdHIc99Vy7V9BaYTUzLeRA8YXYY1aQD1/5I2aqIrO0coi4t6hJPqMisidlBxhyME8UexkHt31SlR6Og==}
+  apg-lite@1.0.5:
+    resolution: {integrity: sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -902,8 +915,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -919,8 +932,8 @@ packages:
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1007,8 +1020,8 @@ packages:
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
-  core-js-pure@3.41.0:
-    resolution: {integrity: sha512-71Gzp96T9YPk63aUvE5Q5qP+DryB4ZloUZPSOebGM88VNw8VNfvdA7z6kGA8iGOTEzAomsRidp4jXSmUIJsL+Q==}
+  core-js-pure@3.47.0:
+    resolution: {integrity: sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1270,8 +1283,8 @@ packages:
   focusable-selectors@0.8.4:
     resolution: {integrity: sha512-0XxbkD0KhOnX10qmnfF9U8DkDD8N/e4M77wMYw2Itoi4vdcoRjSkqXLZFIzkrLIOxzmzCGy88fNG1EbeXMD/zw==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -1283,8 +1296,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   form-serialize@0.7.2:
@@ -1730,8 +1743,8 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-addon-api@8.3.1:
-    resolution: {integrity: sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==}
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
     engines: {node: ^18 || ^20 || >= 21}
 
   node-domexception@1.0.0:
@@ -1975,8 +1988,8 @@ packages:
       redux:
         optional: true
 
-  react-syntax-highlighter@15.6.1:
-    resolution: {integrity: sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==}
+  react-syntax-highlighter@15.6.6:
+    resolution: {integrity: sha512-DgXrc+AZF47+HvAPEmn7Ua/1p10jNoVZVI/LoPiYdtY+OM+/nG5yefLHKJwdKqY1adMuHFbeyBaG9j64ML7vTw==}
     peerDependencies:
       react: '>= 0.14.0'
 
@@ -2002,9 +2015,6 @@ packages:
 
   refractor@3.6.0:
     resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
-
-  regenerator-runtime@0.14.1:
-    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2113,8 +2123,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sha.js@2.4.11:
-    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
     hasBin: true
 
   shebang-command@2.0.0:
@@ -2125,8 +2136,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  short-unique-id@5.2.0:
-    resolution: {integrity: sha512-cMGfwNyfDZ/nzJ2k2M+ClthBIh//GlZl1JEf47Uoa9XR11bz8Pa2T2wQO4bVrRdH48LrIDWJahQziKo3MjhsWg==}
+  short-unique-id@5.3.2:
+    resolution: {integrity: sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==}
     hasBin: true
 
   side-channel-list@1.0.0:
@@ -2210,14 +2221,18 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swagger-client@3.34.4:
-    resolution: {integrity: sha512-Qvtu8DtARAx5GwefA0eV1WRLa4Q9bhczrtNAsiBMOx3HkxAOczy1APQhrcblJdLys0xEGQ4xYizYFXfIL9BhpA==}
+  swagger-client@3.36.0:
+    resolution: {integrity: sha512-9fkjxGHXuKy20jj8zwE6RwgFSOGKAyOD5U7aKgW/+/futtHZHOdZeqiEkb97sptk2rdBv7FEiUQDNlWZR186RA==}
 
-  swagger-ui@5.21.0:
-    resolution: {integrity: sha512-zAY5P5nIWiYOuO0SWQk1x8/kL+pmarijO+oviWOp+SerfMpeokujYk6HknwEoeYNi4CtpO+kBj6Vm+8aswCBIA==}
+  swagger-ui@5.27.1:
+    resolution: {integrity: sha512-cGQyafnHLmVFiBeFrbUzUtMn+R0/XI7r69T/cxp5bkusTdLu1Ul8A+8j9hgThYLEH33LukOzldtiuu4gr8XE6g==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2237,8 +2252,11 @@ packages:
       tree-sitter:
         optional: true
 
-  tree-sitter@0.22.1:
-    resolution: {integrity: sha512-gRO+jk2ljxZlIn20QRskIvpLCMtzuLl5T0BY6L9uvPYD17uUrxlxWkvYCiVqED2q2q7CVtY52Uex4WcYo2FEXw==}
+  tree-sitter@0.21.1:
+    resolution: {integrity: sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==}
+
+  tree-sitter@0.22.4:
+    resolution: {integrity: sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==}
 
   trim-repeated@1.0.0:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
@@ -2312,8 +2330,8 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  use-sync-external-store@1.5.0:
-    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -2440,14 +2458,11 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@babel/runtime-corejs3@7.27.0':
+  '@babel/runtime-corejs3@7.28.4':
     dependencies:
-      core-js-pure: 3.41.0
-      regenerator-runtime: 0.14.1
+      core-js-pure: 3.47.0
 
-  '@babel/runtime@7.27.0':
-    dependencies:
-      regenerator-runtime: 0.14.1
+  '@babel/runtime@7.28.4': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3028,369 +3043,406 @@ snapshots:
       '@stoplight/yaml-ast-parser': 0.0.50
       tslib: 2.8.1
 
-  '@swagger-api/apidom-ast@1.0.0-beta.31':
+  '@swagger-api/apidom-ast@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-error': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-error': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
       unraw: 3.0.0
 
-  '@swagger-api/apidom-core@1.0.0-beta.31':
+  '@swagger-api/apidom-core@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-ast': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-ast': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
       '@types/ramda': 0.30.2
       minim: 0.23.8
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
-      short-unique-id: 5.2.0
+      short-unique-id: 5.3.2
       ts-mixer: 6.0.4
 
-  '@swagger-api/apidom-error@1.0.0-beta.31':
+  '@swagger-api/apidom-error@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
+      '@babel/runtime-corejs3': 7.28.4
 
-  '@swagger-api/apidom-json-pointer@1.0.0-beta.31':
+  '@swagger-api/apidom-json-pointer@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@types/ramda': 0.30.2
-      ramda: 0.30.1
-      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swaggerexpert/json-pointer': 2.10.2
 
-  '@swagger-api/apidom-ns-api-design-systems@1.0.0-beta.31':
+  '@swagger-api/apidom-ns-api-design-systems@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-1': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-1': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
       ts-mixer: 6.0.4
     optional: true
 
-  '@swagger-api/apidom-ns-arazzo-1@1.0.0-beta.31':
+  '@swagger-api/apidom-ns-arazzo-1@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-2020-12': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-2020-12': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
       ts-mixer: 6.0.4
     optional: true
 
-  '@swagger-api/apidom-ns-asyncapi-2@1.0.0-beta.31':
+  '@swagger-api/apidom-ns-asyncapi-2@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-draft-7': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-draft-7': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
       ts-mixer: 6.0.4
     optional: true
 
-  '@swagger-api/apidom-ns-json-schema-2019-09@1.0.0-beta.31':
+  '@swagger-api/apidom-ns-asyncapi-3@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-draft-7': 1.0.0-beta.31
-      '@types/ramda': 0.30.2
-      ramda: 0.30.1
-      ramda-adjunct: 5.1.0(ramda@0.30.1)
-      ts-mixer: 6.0.4
-
-  '@swagger-api/apidom-ns-json-schema-2020-12@1.0.0-beta.31':
-    dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-2019-09': 1.0.0-beta.31
-      '@types/ramda': 0.30.2
-      ramda: 0.30.1
-      ramda-adjunct: 5.1.0(ramda@0.30.1)
-      ts-mixer: 6.0.4
-
-  '@swagger-api/apidom-ns-json-schema-draft-4@1.0.0-beta.31':
-    dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-ast': 1.0.0-beta.31
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@types/ramda': 0.30.2
-      ramda: 0.30.1
-      ramda-adjunct: 5.1.0(ramda@0.30.1)
-      ts-mixer: 6.0.4
-
-  '@swagger-api/apidom-ns-json-schema-draft-6@1.0.0-beta.31':
-    dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-draft-4': 1.0.0-beta.31
-      '@types/ramda': 0.30.2
-      ramda: 0.30.1
-      ramda-adjunct: 5.1.0(ramda@0.30.1)
-      ts-mixer: 6.0.4
-
-  '@swagger-api/apidom-ns-json-schema-draft-7@1.0.0-beta.31':
-    dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-draft-6': 1.0.0-beta.31
-      '@types/ramda': 0.30.2
-      ramda: 0.30.1
-      ramda-adjunct: 5.1.0(ramda@0.30.1)
-      ts-mixer: 6.0.4
-
-  '@swagger-api/apidom-ns-openapi-2@1.0.0-beta.31':
-    dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-draft-4': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-asyncapi-2': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
       ts-mixer: 6.0.4
     optional: true
 
-  '@swagger-api/apidom-ns-openapi-3-0@1.0.0-beta.31':
+  '@swagger-api/apidom-ns-json-schema-2019-09@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-draft-4': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-draft-7': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
       ts-mixer: 6.0.4
 
-  '@swagger-api/apidom-ns-openapi-3-1@1.0.0-beta.31':
+  '@swagger-api/apidom-ns-json-schema-2020-12@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-ast': 1.0.0-beta.31
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-json-pointer': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-json-schema-2020-12': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-0': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-2019-09': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
       ts-mixer: 6.0.4
 
-  '@swagger-api/apidom-parser-adapter-api-design-systems-json@1.0.0-beta.31':
+  '@swagger-api/apidom-ns-json-schema-draft-4@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-api-design-systems': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-json': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-ast': 1.0.2
+      '@swagger-api/apidom-core': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      ts-mixer: 6.0.4
+
+  '@swagger-api/apidom-ns-json-schema-draft-6@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-draft-4': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      ts-mixer: 6.0.4
+
+  '@swagger-api/apidom-ns-json-schema-draft-7@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-draft-6': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      ts-mixer: 6.0.4
+
+  '@swagger-api/apidom-ns-openapi-2@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-draft-4': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      ts-mixer: 6.0.4
+    optional: true
+
+  '@swagger-api/apidom-ns-openapi-3-0@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-draft-4': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      ts-mixer: 6.0.4
+
+  '@swagger-api/apidom-ns-openapi-3-1@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-ast': 1.0.2
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-json-pointer': 1.0.2
+      '@swagger-api/apidom-ns-json-schema-2020-12': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-0': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      ts-mixer: 6.0.4
+
+  '@swagger-api/apidom-parser-adapter-api-design-systems-json@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-api-design-systems': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-api-design-systems-yaml@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-api-design-systems-yaml@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-api-design-systems': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-api-design-systems': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-arazzo-json-1@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-arazzo-json-1@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-arazzo-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-json': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-arazzo-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-arazzo-yaml-1@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-arazzo-yaml-1@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-arazzo-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-arazzo-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-asyncapi-json-2@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-asyncapi-json-2@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-asyncapi-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-json': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-asyncapi-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-asyncapi-json-3@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-asyncapi-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-asyncapi-3': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-json@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-ast': 1.0.0-beta.31
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-asyncapi-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
-      tree-sitter: 0.22.1
-      tree-sitter-json: 0.24.8(tree-sitter@0.22.1)
+    optional: true
+
+  '@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-asyncapi-3': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+    optional: true
+
+  '@swagger-api/apidom-parser-adapter-json@1.0.2':
+    dependencies:
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-ast': 1.0.2
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@types/ramda': 0.30.2
+      ramda: 0.30.1
+      ramda-adjunct: 5.1.0(ramda@0.30.1)
+      tree-sitter: 0.21.1
+      tree-sitter-json: 0.24.8(tree-sitter@0.21.1)
       web-tree-sitter: 0.24.5
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-openapi-json-2@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-openapi-json-2@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-json': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-openapi-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-openapi-json-3-0@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-openapi-json-3-0@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-0': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-json': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-0': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-openapi-json-3-1@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-openapi-json-3-1@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-json': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-openapi-yaml-2@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-openapi-yaml-2@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-openapi-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-0': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-0': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optional: true
 
-  '@swagger-api/apidom-parser-adapter-yaml-1-2@1.0.0-beta.31':
+  '@swagger-api/apidom-parser-adapter-yaml-1-2@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-ast': 1.0.0-beta.31
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@tree-sitter-grammars/tree-sitter-yaml': 0.7.0(tree-sitter@0.22.1)
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-ast': 1.0.2
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@tree-sitter-grammars/tree-sitter-yaml': 0.7.1(tree-sitter@0.22.4)
       '@types/ramda': 0.30.2
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
-      tree-sitter: 0.22.1
+      tree-sitter: 0.22.4
       web-tree-sitter: 0.24.5
     optional: true
 
-  '@swagger-api/apidom-reference@1.0.0-beta.31':
+  '@swagger-api/apidom-reference@1.0.2':
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
+      '@babel/runtime-corejs3': 7.28.4
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
       '@types/ramda': 0.30.2
-      axios: 1.9.0
+      axios: 1.13.2
       minimatch: 7.4.6
       process: 0.11.10
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     optionalDependencies:
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-json-pointer': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-arazzo-1': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-asyncapi-2': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-2': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-0': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-api-design-systems-json': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-api-design-systems-yaml': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-arazzo-json-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-arazzo-yaml-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-asyncapi-json-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-json': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-openapi-json-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-openapi-json-3-0': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-openapi-json-3-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-openapi-yaml-2': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1': 1.0.0-beta.31
-      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.0-beta.31
+      '@swagger-api/apidom-json-pointer': 1.0.2
+      '@swagger-api/apidom-ns-arazzo-1': 1.0.2
+      '@swagger-api/apidom-ns-asyncapi-2': 1.0.2
+      '@swagger-api/apidom-ns-openapi-2': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-0': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-api-design-systems-json': 1.0.2
+      '@swagger-api/apidom-parser-adapter-api-design-systems-yaml': 1.0.2
+      '@swagger-api/apidom-parser-adapter-arazzo-json-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-arazzo-yaml-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-asyncapi-json-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-asyncapi-json-3': 1.0.2
+      '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-asyncapi-yaml-3': 1.0.2
+      '@swagger-api/apidom-parser-adapter-json': 1.0.2
+      '@swagger-api/apidom-parser-adapter-openapi-json-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-openapi-json-3-0': 1.0.2
+      '@swagger-api/apidom-parser-adapter-openapi-json-3-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-openapi-yaml-2': 1.0.2
+      '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0': 1.0.2
+      '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1': 1.0.2
+      '@swagger-api/apidom-parser-adapter-yaml-1-2': 1.0.2
     transitivePeerDependencies:
       - debug
 
   '@swaggerexpert/cookie@2.0.2':
     dependencies:
-      apg-lite: 1.0.4
+      apg-lite: 1.0.5
 
-  '@tree-sitter-grammars/tree-sitter-yaml@0.7.0(tree-sitter@0.22.1)':
+  '@swaggerexpert/json-pointer@2.10.2':
     dependencies:
-      node-addon-api: 8.3.1
+      apg-lite: 1.0.5
+
+  '@tree-sitter-grammars/tree-sitter-yaml@0.7.1(tree-sitter@0.22.4)':
+    dependencies:
+      node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
     optionalDependencies:
-      tree-sitter: 0.22.1
+      tree-sitter: 0.22.4
     optional: true
 
   '@types/es-aggregate-error@1.0.6':
@@ -3476,7 +3528,7 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  apg-lite@1.0.4: {}
+  apg-lite@1.0.5: {}
 
   argparse@1.0.10:
     dependencies:
@@ -3535,10 +3587,10 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.9.0:
+  axios@1.13.2:
     dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -3556,7 +3608,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -3645,7 +3697,7 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  core-js-pure@3.41.0: {}
+  core-js-pure@3.47.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3997,17 +4049,18 @@ snapshots:
 
   focusable-selectors@0.8.4: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.11: {}
 
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.2:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   form-serialize@0.7.2: {}
@@ -4429,7 +4482,7 @@ snapshots:
 
   minimatch@7.4.6:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   ms@2.1.3: {}
 
@@ -4454,7 +4507,7 @@ snapshots:
   node-addon-api@7.1.1:
     optional: true
 
-  node-addon-api@8.3.1:
+  node-addon-api@8.5.0:
     optional: true
 
   node-domexception@1.0.0: {}
@@ -4501,11 +4554,11 @@ snapshots:
 
   openapi-path-templating@2.2.1:
     dependencies:
-      apg-lite: 1.0.4
+      apg-lite: 1.0.5
 
   openapi-server-url-templating@1.3.0:
     dependencies:
-      apg-lite: 1.0.4
+      apg-lite: 1.0.5
 
   optionator@0.9.4:
     dependencies:
@@ -4665,13 +4718,13 @@ snapshots:
     dependencies:
       '@types/use-sync-external-store': 0.0.6
       react: 18.3.1
-      use-sync-external-store: 1.5.0(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       redux: 5.0.1
 
-  react-syntax-highlighter@15.6.1(react@18.3.1):
+  react-syntax-highlighter@15.6.6(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.4
       highlight.js: 10.7.3
       highlightjs-vue: 1.0.0
       lowlight: 1.20.0
@@ -4707,8 +4760,6 @@ snapshots:
       hastscript: 6.0.0
       parse-entities: 2.0.0
       prismjs: 1.27.0
-
-  regenerator-runtime@0.14.1: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -4847,10 +4898,11 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  sha.js@2.4.11:
+  sha.js@2.4.12:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -4858,7 +4910,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  short-unique-id@5.2.0: {}
+  short-unique-id@5.3.2: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -4954,15 +5006,15 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swagger-client@3.34.4:
+  swagger-client@3.36.0:
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
+      '@babel/runtime-corejs3': 7.28.4
       '@scarf/scarf': 1.4.0
-      '@swagger-api/apidom-core': 1.0.0-beta.31
-      '@swagger-api/apidom-error': 1.0.0-beta.31
-      '@swagger-api/apidom-json-pointer': 1.0.0-beta.31
-      '@swagger-api/apidom-ns-openapi-3-1': 1.0.0-beta.31
-      '@swagger-api/apidom-reference': 1.0.0-beta.31
+      '@swagger-api/apidom-core': 1.0.2
+      '@swagger-api/apidom-error': 1.0.2
+      '@swagger-api/apidom-json-pointer': 1.0.2
+      '@swagger-api/apidom-ns-openapi-3-1': 1.0.2
+      '@swagger-api/apidom-reference': 1.0.2
       '@swaggerexpert/cookie': 2.0.2
       deepmerge: 4.3.1
       fast-json-patch: 3.1.1
@@ -4977,9 +5029,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  swagger-ui@5.21.0:
+  swagger-ui@5.27.1:
     dependencies:
-      '@babel/runtime-corejs3': 7.27.0
+      '@babel/runtime-corejs3': 7.28.4
       '@scarf/scarf': 1.4.0
       base64-js: 1.5.1
       classnames: 2.5.1
@@ -5002,14 +5054,14 @@ snapshots:
       react-immutable-pure-component: 2.2.2(immutable@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-inspector: 6.0.2(react@18.3.1)
       react-redux: 9.2.0(react@18.3.1)(redux@5.0.1)
-      react-syntax-highlighter: 15.6.1(react@18.3.1)
+      react-syntax-highlighter: 15.6.6(react@18.3.1)
       redux: 5.0.1
       redux-immutable: 4.0.0(immutable@3.8.2)
       remarkable: 2.0.1
       reselect: 5.1.1
       serialize-error: 8.1.0
-      sha.js: 2.4.11
-      swagger-client: 3.34.4
+      sha.js: 2.4.12
+      swagger-client: 3.36.0
       url-parse: 1.5.10
       xml: 1.0.1
       xml-but-prettier: 1.0.1
@@ -5020,6 +5072,12 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5028,17 +5086,23 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  tree-sitter-json@0.24.8(tree-sitter@0.22.1):
+  tree-sitter-json@0.24.8(tree-sitter@0.21.1):
     dependencies:
-      node-addon-api: 8.3.1
+      node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
     optionalDependencies:
-      tree-sitter: 0.22.1
+      tree-sitter: 0.21.1
     optional: true
 
-  tree-sitter@0.22.1:
+  tree-sitter@0.21.1:
     dependencies:
-      node-addon-api: 8.3.1
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+    optional: true
+
+  tree-sitter@0.22.4:
+    dependencies:
+      node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
     optional: true
 
@@ -5127,7 +5191,7 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  use-sync-external-store@1.5.0(react@18.3.1):
+  use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
Update minor versions of:
- eslint
- @eslint/compat
- swagger-ui

to fix some dependabot security warnings.