### PR TITLE
Adjust planned brownout schedule

### DIFF
--- a/source/docs/nlr-domain-transition.html.md
+++ b/source/docs/nlr-domain-transition.html.md
@@ -21,116 +21,181 @@ Here is a timeline for this domain change:
         <table class="table table-bordered">
           <thead>
             <tr>
-              <th>Brownout Date</th>
-              <th>Brownout Start Time</th>
-              <th>Brownout End Time</th>
+              <th>Brownout Start</th>
+              <th>Brownout End</th>
+              <th>Brownout Duration</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td><code>Fri, 01 May 2026</code></td>
-              <td><code>09:00:00 PM EDT</code></td>
-              <td><code>09:30:00 PM EDT</code></td>
+              <td><code>Fri, 01 May 2026, 09:00:00 PM EDT</code></td>
+              <td><code>Fri, 01 May 2026, 10:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Sun, 03 May 2026</code></td>
-              <td><code>09:00:00 PM EDT</code></td>
-              <td><code>09:30:00 PM EDT</code></td>
+              <td><code>Sat, 02 May 2026, 06:00:00 PM EDT</code></td>
+              <td><code>Sat, 02 May 2026, 07:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Tue, 05 May 2026</code></td>
-              <td><code>09:00:00 PM EDT</code></td>
-              <td><code>10:00:00 PM EDT</code></td>
+              <td><code>Sun, 03 May 2026, 08:00:00 AM EDT</code></td>
+              <td><code>Sun, 03 May 2026, 09:00:00 AM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Thu, 07 May 2026</code></td>
-              <td><code>09:00:00 PM EDT</code></td>
-              <td><code>10:00:00 PM EDT</code></td>
+              <td><code>Mon, 04 May 2026, 11:00:00 AM EDT</code></td>
+              <td><code>Mon, 04 May 2026, 11:15:00 AM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Sun, 10 May 2026</code></td>
-              <td><code>04:00:00 PM EDT</code></td>
-              <td><code>05:00:00 PM EDT</code></td>
+              <td><code>Tue, 05 May 2026, 09:00:00 PM EDT</code></td>
+              <td><code>Tue, 05 May 2026, 10:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Tue, 12 May 2026</code></td>
-              <td><code>11:00:00 AM EDT</code></td>
-              <td><code>11:15:00 AM EDT</code></td>
+              <td><code>Wed, 06 May 2026, 01:00:00 PM EDT</code></td>
+              <td><code>Wed, 06 May 2026, 01:15:00 PM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Wed, 13 May 2026</code></td>
-              <td><code>04:00:00 PM EDT</code></td>
-              <td><code>04:15:00 PM EDT</code></td>
+              <td><code>Thu, 07 May 2026, 09:00:00 PM EDT</code></td>
+              <td><code>Thu, 07 May 2026, 10:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Wed, 13 May 2026</code></td>
-              <td><code>09:00:00 PM EDT</code></td>
-              <td><code>10:00:00 PM EDT</code></td>
+              <td><code>Fri, 08 May 2026, 03:00:00 PM EDT</code></td>
+              <td><code>Fri, 08 May 2026, 03:15:00 PM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Wed, 13 May 2026</code></td>
-              <td><code>01:00:00 PM EDT</code></td>
-              <td><code>01:15:00 PM EDT</code></td>
+              <td><code>Sat, 09 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>Sat, 09 May 2026, 01:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Sat, 16 May 2026</code></td>
-              <td><code>03:00:00 PM EDT</code></td>
-              <td><code>05:00:00 PM EDT</code></td>
+              <td><code>Sun, 10 May 2026, 04:00:00 PM EDT</code></td>
+              <td><code>Sun, 10 May 2026, 05:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Mon, 18 May 2026</code></td>
-              <td><code>10:00:00 AM EDT</code></td>
-              <td><code>10:15:00 AM EDT</code></td>
+              <td><code>Mon, 11 May 2026, 09:30:00 AM EDT</code></td>
+              <td><code>Mon, 11 May 2026, 09:45:00 AM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Tue, 19 May 2026</code></td>
-              <td><code>11:00:00 AM EDT</code></td>
-              <td><code>11:15:00 AM EDT</code></td>
+              <td><code>Tue, 12 May 2026, 11:30:00 AM EDT</code></td>
+              <td><code>Tue, 12 May 2026, 11:45:00 AM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Wed, 20 May 2026</code></td>
-              <td><code>12:00:00 PM EDT</code></td>
-              <td><code>12:15:00 PM EDT</code></td>
+              <td><code>Wed, 13 May 2026, 01:30:00 PM EDT</code></td>
+              <td><code>Wed, 13 May 2026, 01:45:00 PM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Thu, 21 May 2026</code></td>
-              <td><code>01:00:00 PM EDT</code></td>
-              <td><code>01:30:00 PM EDT</code></td>
+              <td><code>Wed, 13 May 2026, 09:00:00 PM EDT</code></td>
+              <td><code>Wed, 13 May 2026, 10:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
             </tr>
             <tr>
-              <td><code>Fri, 22 May 2026</code></td>
-              <td><code>02:00:00 PM EDT</code></td>
-              <td><code>02:30:00 PM EDT</code></td>
+              <td><code>Thu, 14 May 2026, 03:30:00 PM EDT</code></td>
+              <td><code>Thu, 14 May 2026, 03:45:00 PM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Sat, 23 May 2026</code></td>
-              <td><code>01:00:00 PM EDT</code></td>
-              <td><code>04:00:00 PM EDT</code></td>
+              <td><code>Fri, 15 May 2026, 05:30:00 PM EDT</code></td>
+              <td><code>Fri, 15 May 2026, 05:45:00 PM EDT</code></td>
+              <td><code>15m</code></td>
             </tr>
             <tr>
-              <td><code>Sun, 24 May 2026</code></td>
-              <td><code>12:00:00 PM EDT</code></td>
-              <td><code>03:00:00 PM EDT</code></td>
+              <td><code>Sat, 16 May 2026, 03:00:00 PM EDT</code></td>
+              <td><code>Sat, 16 May 2026, 05:00:00 PM EDT</code></td>
+              <td><code>120m</code></td>
             </tr>
             <tr>
-              <td><code>Mon, 25 May 2026</code></td>
-              <td><code>09:00:00 AM EDT</code></td>
-              <td><code>11:00:00 AM EDT</code></td>
+              <td><code>Sun, 17 May 2026, 03:00:00 PM EDT</code></td>
+              <td><code>Sun, 17 May 2026, 05:00:00 PM EDT</code></td>
+              <td><code>120m</code></td>
             </tr>
             <tr>
-              <td><code>Tue, 26 May 2026</code></td>
-              <td><code>11:00:00 AM EDT</code></td>
-              <td><code>01:00:00 PM EDT</code></td>
+              <td><code>Mon, 18 May 2026, 10:00:00 AM EDT</code></td>
+              <td><code>Mon, 18 May 2026, 10:30:00 AM EDT</code></td>
+              <td><code>30m</code></td>
             </tr>
             <tr>
-              <td><code>Wed, 27 May 2026</code></td>
-              <td><code>01:00:00 PM EDT</code></td>
-              <td><code>03:00:00 PM EDT</code></td>
+              <td><code>Tue, 19 May 2026, 11:30:00 AM EDT</code></td>
+              <td><code>Tue, 19 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>30m</code></td>
             </tr>
             <tr>
-              <td><code>Thu, 28 May 2026</code></td>
-              <td><code>03:00:00 PM EDT</code></td>
-              <td><code>05:00:00 PM EDT</code></td>
+              <td><code>Wed, 20 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>Wed, 20 May 2026, 12:30:00 PM EDT</code></td>
+              <td><code>30m</code></td>
+            </tr>
+            <tr>
+              <td><code>Thu, 21 May 2026, 01:00:00 PM EDT</code></td>
+              <td><code>Thu, 21 May 2026, 01:45:00 PM EDT</code></td>
+              <td><code>45m</code></td>
+            </tr>
+            <tr>
+              <td><code>Fri, 22 May 2026, 02:00:00 PM EDT</code></td>
+              <td><code>Fri, 22 May 2026, 02:45:00 PM EDT</code></td>
+              <td><code>45m</code></td>
+            </tr>
+            <tr>
+              <td><code>Fri, 22 May 2026, 09:00:00 PM EDT</code></td>
+              <td><code>Sat, 23 May 2026, 02:00:00 AM EDT</code></td>
+              <td><code>300m</code></td>
+            </tr>
+            <tr>
+              <td><code>Sat, 23 May 2026, 01:00:00 PM EDT</code></td>
+              <td><code>Sat, 23 May 2026, 04:00:00 PM EDT</code></td>
+              <td><code>180m</code></td>
+            </tr>
+            <tr>
+              <td><code>Sun, 24 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>Sun, 24 May 2026, 03:00:00 PM EDT</code></td>
+              <td><code>180m</code></td>
+            </tr>
+            <tr>
+              <td><code>Mon, 25 May 2026, 02:00:00 AM EDT</code></td>
+              <td><code>Mon, 25 May 2026, 07:00:00 AM EDT</code></td>
+              <td><code>300m</code></td>
+            </tr>
+            <tr>
+              <td><code>Mon, 25 May 2026, 11:00:00 AM EDT</code></td>
+              <td><code>Mon, 25 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
+            </tr>
+            <tr>
+              <td><code>Tue, 26 May 2026, 07:00:00 AM EDT</code></td>
+              <td><code>Tue, 26 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>300m</code></td>
+            </tr>
+            <tr>
+              <td><code>Tue, 26 May 2026, 02:00:00 PM EDT</code></td>
+              <td><code>Tue, 26 May 2026, 03:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
+            </tr>
+            <tr>
+              <td><code>Wed, 27 May 2026, 07:00:00 AM EDT</code></td>
+              <td><code>Wed, 27 May 2026, 08:00:00 AM EDT</code></td>
+              <td><code>60m</code></td>
+            </tr>
+            <tr>
+              <td><code>Wed, 27 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>Wed, 27 May 2026, 05:00:00 PM EDT</code></td>
+              <td><code>300m</code></td>
+            </tr>
+            <tr>
+              <td><code>Thu, 28 May 2026, 11:00:00 AM EDT</code></td>
+              <td><code>Thu, 28 May 2026, 12:00:00 PM EDT</code></td>
+              <td><code>60m</code></td>
+            </tr>
+            <tr>
+              <td><code>Thu, 28 May 2026, 05:00:00 PM EDT</code></td>
+              <td><code>Fri, 29 May 2026, 12:00:00 AM EDT</code></td>
+              <td><code>420m</code></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
To try and ensure we catch more people sooner (rather than waiting until the final week), and also ensure we have more coverage of some outage during every hour of the day in the final week.