### PR TITLE
Adds 2025 to docs for solar download

### DIFF
--- a/frontend/lib/font_awesome_icons.js
+++ b/frontend/lib/font_awesome_icons.js
@@ -1,4 +1,5 @@
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
+import { faBullhorn } from '@fortawesome/free-solid-svg-icons/faBullhorn';
 import { faComments } from '@fortawesome/free-solid-svg-icons/faComments';
 import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
 import { faInstagram } from '@fortawesome/free-brands-svg-icons/faInstagram';
@@ -14,6 +15,7 @@ import { library, dom } from '@fortawesome/fontawesome-svg-core';
 
 library.add(
   faBars,
+  faBullhorn,
   faComments,
   faGithub,
   faInstagram,

--- a/source/docs/solar/nsrdb/dynamic_spectral_data_download.html.md.erb
+++ b/source/docs/solar/nsrdb/dynamic_spectral_data_download.html.md.erb
@@ -5,6 +5,13 @@ detail: This API is capable of creating very large downloadable archives. Unlike
 url: /api/nsrdb_api/solar/spectral_ondemand_download
 ---
 
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+  <i class="fa fa-bullhorn bi flex-shrink-0 me-2 fa-width-auto"></i>
+  <p class="m-0 lh-sm">
+    <strong>NSRDB 2025 GOES satellite data for the western hemisphere is now available.</strong> Read more on the NSRDB <a href="https://nsrdb.nlr.gov/about/announcements">Announcements Page</a>
+  </p>
+</div>
+
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 <%= current_page.data.summary %>
 

--- a/source/docs/solar/nsrdb/dynamic_spectral_data_download.html.md.erb
+++ b/source/docs/solar/nsrdb/dynamic_spectral_data_download.html.md.erb
@@ -57,7 +57,7 @@ _NOTE: when using POST to submit a request the api_key must still be included as
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field"><strong>Type:</strong> integer</div>
         <div class="doc-parameter-value-field"><strong>Default:</strong> None</div>
-        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024</em></div>
+        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025</em></div>
       </td>
       <td class="doc-parameter-description">The year for which data should be extracted.</td>
     </tr>

--- a/source/docs/solar/nsrdb/index.html.md.erb
+++ b/source/docs/solar/nsrdb/index.html.md.erb
@@ -4,6 +4,19 @@ summary: Freely available downloads of The National Solar Radiation Database.
 
 ---
 
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+  <i class="fa fa-bullhorn bi flex-shrink-0 me-2 fa-width-auto"></i>
+  <p class="m-0 lh-sm">
+    <strong>NSRDB 2025 GOES satellite data for the western hemisphere is now available.</strong> Read more on the NSRDB <a href="https://nsrdb.nlr.gov/announcements/">Announcements Page</a><br />
+  </p>
+  <ul class="m-0 lh-sm">
+    <li><a href="./nsrdb-GOES-aggregated-v4-0-0-download/">GOES Aggregated</a></li>
+    <li><a href="./nsrdb-GOES-conus-v4-0-0-download/">GOES CONUS</a></li>
+    <li><a href="./nsrdb-GOES-full-disc-v4-0-0-download/">GOES Full Disc</a></li>
+    <li><a href="./dynamic_spectral_data_download/">Dynamic Spectral Data</a></li>
+  </ul>
+</div>
+
 # <%= current_page.data.title %>
 <%= current_page.data.summary %>
 

--- a/source/docs/solar/nsrdb/nsrdb-GOES-aggregated-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-aggregated-v4-0-0-download.html.md.erb
@@ -69,7 +69,7 @@ _NOTE: when using POST to submit a request the api_key must still be included as
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field"><strong>Type:</strong> comma delimited string array</div>
         <div class="doc-parameter-value-field"><strong>Default:</strong> None</div>
-        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024</em>.</div>
+        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025</em>.</div>
       </td>
       <td class="doc-parameter-description">The year(s) for which data should be extracted.</td>
     </tr>

--- a/source/docs/solar/nsrdb/nsrdb-GOES-aggregated-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-aggregated-v4-0-0-download.html.md.erb
@@ -5,6 +5,13 @@ detail: This API is capable of creating very large downloadable archives. Unlike
 url: /api/nsrdb/v2/solar/nsrdb-GOES-aggregated-v4-0-0-download
 ---
 
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+  <i class="fa fa-bullhorn bi flex-shrink-0 me-2 fa-width-auto"></i>
+  <p class="m-0 lh-sm">
+    <strong>NSRDB 2025 GOES satellite data for the western hemisphere is now available.</strong> Read more on the NSRDB <a href="https://nsrdb.nlr.gov/about/announcements">Announcements Page</a>
+  </p>
+</div>
+
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 <%= current_page.data.summary %>
 

--- a/source/docs/solar/nsrdb/nsrdb-GOES-conus-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-conus-v4-0-0-download.html.md.erb
@@ -69,7 +69,7 @@ _NOTE: when using POST to submit a request the api_key must still be included as
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field"><strong>Type:</strong> comma delimited string array</div>
         <div class="doc-parameter-value-field"><strong>Default:</strong> None</div>
-        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>2018, 2019, 2020, 2021, 2022, 2023, 2024</em>.</div>
+        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025</em>.</div>
       </td>
       <td class="doc-parameter-description">The year(s) for which data should be extracted.</td>
     </tr>

--- a/source/docs/solar/nsrdb/nsrdb-GOES-conus-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-conus-v4-0-0-download.html.md.erb
@@ -5,6 +5,13 @@ detail: This API is capable of creating very large downloadable archives. Unlike
 url: /api/nsrdb/v2/solar/nsrdb-GOES-conus-v4-0-0-download
 ---
 
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+  <i class="fa fa-bullhorn bi flex-shrink-0 me-2 fa-width-auto"></i>
+  <p class="m-0 lh-sm">
+    <strong>NSRDB 2025 GOES satellite data for the western hemisphere is now available.</strong> Read more on the NSRDB <a href="https://nsrdb.nlr.gov/about/announcements">Announcements Page</a>
+  </p>
+</div>
+
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 <%= current_page.data.summary %>
 

--- a/source/docs/solar/nsrdb/nsrdb-GOES-full-disc-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-full-disc-v4-0-0-download.html.md.erb
@@ -69,7 +69,7 @@ _NOTE: when using POST to submit a request the api_key must still be included as
       <td class="doc-parameter-value">
         <div class="doc-parameter-value-field"><strong>Type:</strong> comma delimited string array</div>
         <div class="doc-parameter-value-field"><strong>Default:</strong> None</div>
-        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>2018, 2019, 2020, 2021, 2022, 2023, 2024</em>.</div>
+        <div class="doc-parameter-value-field"><strong>Options:</strong> <em>2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025</em>.</div>
       </td>
       <td class="doc-parameter-description">The year(s) for which data should be extracted.</td>
     </tr>

--- a/source/docs/solar/nsrdb/nsrdb-GOES-full-disc-v4-0-0-download.html.md.erb
+++ b/source/docs/solar/nsrdb/nsrdb-GOES-full-disc-v4-0-0-download.html.md.erb
@@ -5,6 +5,13 @@ detail: This API is capable of creating very large downloadable archives. Unlike
 url: /api/nsrdb/v2/solar/nsrdb-GOES-full-disc-v4-0-0-download
 ---
 
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+  <i class="fa fa-bullhorn bi flex-shrink-0 me-2 fa-width-auto"></i>
+  <p class="m-0 lh-sm">
+    <strong>NSRDB 2025 GOES satellite data for the western hemisphere is now available.</strong> Read more on the NSRDB <a href="https://nsrdb.nlr.gov/about/announcements">Announcements Page</a>
+  </p>
+</div>
+
 # <%= current_page.data.title %> <span class="url">(<%= current_page.data.url %>)</span>
 <%= current_page.data.summary %>
 


### PR DESCRIPTION
A trivial update adding "2025" to the list of years for the relevant NSRDB datasets.