### PR TITLE
Remove yellow banners about domain name change.

### DIFF
--- a/source/docs/nlr-domain-transition.html.md
+++ b/source/docs/nlr-domain-transition.html.md
@@ -1,7 +1,6 @@
 ---
 title: NLR.gov Domain Transition
 hidden_child: true
-hide_domain_transition_link: true
 ---
 
 # NLR.gov Domain Transition

--- a/source/docs/widget-embed-code.html.md
+++ b/source/docs/widget-embed-code.html.md
@@ -4,13 +4,6 @@ hidden_child: true
 hide_domain_transition_alert: true
 ---
 
-<div class="alert alert-warning d-flex align-items-center" role="alert">
-  <i class="fa-solid fa-triangle-exclamation bi flex-shrink-0 me-2 fa-width-auto"></i>
-  <p class="m-0 lh-sm">
-    <strong>Website Owners:</strong> Update any <code>nrel.gov</code> references in your widget embed code to <code>nlr.gov</code>.
-  </p>
-</div>
-
 # Updating Embed Code for NLR.gov Widgets
 
 The National Laboratory of the Rockies (NLR) retired the `nrel.gov` domain on May 29, 2026, after transitioning to the new `nlr.gov` domain.

--- a/source/docs/widget-embed-code.html.md
+++ b/source/docs/widget-embed-code.html.md
@@ -1,7 +1,6 @@
 ---
 title: Updating Embed Code for NLR.gov Widgets
 hidden_child: true
-hide_domain_transition_alert: true
 ---
 
 # Updating Embed Code for NLR.gov Widgets

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -34,18 +34,6 @@
     <main id="content" class="container-xl">
       <%= partial("layouts/breadcrumbs") %>
 
-      <% unless current_page.data.hide_domain_transition_alert %>
-        <div class="alert alert-warning d-flex align-items-center" role="alert">
-          <i class="fa-solid fa-triangle-exclamation bi flex-shrink-0 me-2 fa-width-auto"></i>
-          <p class="m-0 lh-sm">
-            <strong>Existing API Users:</strong> Update any <code>developer.nrel.gov</code> references in your code to <code>developer.nlr.gov</code>. The previous <code>developer.nrel.gov</code> domain was retired on May 29, 2026.
-            <% unless current_page.data.hide_domain_transition_link %>
-              Learn more about the <%= link_to("domain transition", "/docs/nlr-domain-transition.html") %>.
-            <% end %>
-          </p>
-        </div>
-      <% end %>
-
       <%= yield %>
 
       <%= partial("layouts/edit_me") %>


### PR DESCRIPTION
Removes the yellow banner alerts at https://developer.nlr.gov/, https://developer.nlr.gov/docs/nlr-domain-transition/ , and https://developer.nlr.gov/docs/widget-embed-code/ about the domain transition that we no longer need. 

Staging: https://devstage.nlr.gov/.